### PR TITLE
Preserve base64 padding in runtime-secret stdin parser

### DIFF
--- a/contrib/loupe-server-runtime-secrets.sh
+++ b/contrib/loupe-server-runtime-secrets.sh
@@ -119,9 +119,11 @@ set_runtime_env() {
 	systemd_env_names="$systemd_env_names $name"
 }
 
-while IFS='=' read -r name encoded; do
-	[ -n "$name" ] || continue
-	if [ -z "$encoded" ]; then
+while IFS= read -r line; do
+	[ -n "$line" ] || continue
+	name="${line%%=*}"
+	encoded="${line#*=}"
+	if [ "$name" = "$line" ] || [ -z "$encoded" ]; then
 		echo "error: missing base64 value for $name" >&2
 		exit 2
 	fi

--- a/contrib/loupe-worker-runtime-secrets.sh
+++ b/contrib/loupe-worker-runtime-secrets.sh
@@ -115,9 +115,11 @@ set_runtime_env() {
 	systemd_env_names="$systemd_env_names $name"
 }
 
-while IFS='=' read -r name encoded; do
-	[ -n "$name" ] || continue
-	if [ -z "$encoded" ]; then
+while IFS= read -r line; do
+	[ -n "$line" ] || continue
+	name="${line%%=*}"
+	encoded="${line#*=}"
+	if [ "$name" = "$line" ] || [ -z "$encoded" ]; then
 		echo "error: missing base64 value for $name" >&2
 		exit 2
 	fi


### PR DESCRIPTION
Found when trying to deploy my own

The server and worker runtime-secret helpers read NAME=B64VALUE lines from stdin to inject TLS PEMs and other credentials into systemd's manager environment. Both used `IFS='=' read -r name encoded`, which treats every `=` in the line as a field delimiter and strips trailing delimiter characters. When a base64-encoded payload ends in `=` or `==` padding -- common for PEM certificate blobs whose decoded length is not a multiple of 3 -- those padding bytes are dropped before the helper sees them, so the encoded length is no longer a multiple of 4 and `base64 -d` aborts the deploy with `base64: invalid input`.

Replace the IFS-driven split with `IFS= read -r line` plus parameter expansion on the first `=`, which keeps the rest of the line, including trailing padding, verbatim. Payloads with shorter values that happen to encode without padding (the 32-byte master key, ECDSA keys) round-tripped fine under the old code; this fix is what unblocks PEM certificate injection.