### PR TITLE
Bind systemd-resolved runtime dir so DNS works in sandbox

### DIFF
--- a/crates/loupe-worker/src/sandbox.rs
+++ b/crates/loupe-worker/src/sandbox.rs
@@ -182,6 +182,24 @@ impl SandboxBuilder {
 			}
 		}
 
+		// On systemd-resolved hosts (Ubuntu / most modern distros)
+		// /etc/resolv.conf is a symlink into /run/systemd/resolve/, so
+		// binding /etc alone leaves the symlink dangling and DNS dies
+		// inside the sandbox even with `--share-net`. Binding the
+		// symlink target onto /etc/resolv.conf doesn't work either:
+		// bwrap follows the existing dangling symlink during destination
+		// creation and fails with ENOENT. Instead, bind the symlink
+		// target's parent dir at its real path so the symlink resolves
+		// without us having to overlay /etc/resolv.conf itself.
+		if self.allow_network {
+			if let Ok(real) = std::fs::canonicalize("/etc/resolv.conf") {
+				if let Some(parent) = real.parent() {
+					let parent = parent.to_string_lossy().into_owned();
+					cmd.args(["--ro-bind-try", &parent, &parent]);
+				}
+			}
+		}
+
 		cmd.args(["--proc", "/proc", "--dev", "/dev"]);
 
 		// Fresh tmpfs for /tmp and a new $HOME. *Must* come before


### PR DESCRIPTION
The worker sandbox uses bwrap with `--share-net` to let LLM CLIs reach their upstream APIs while still isolating the filesystem and other namespaces. On systemd-resolved hosts (most modern distros, certainly default Ubuntu/Debian/Fedora) `/etc/resolv.conf` is a symlink into `/run/systemd/resolve/`. The existing setup ro-binds `/etc` but not `/run`, so the symlink target is absent inside the sandbox and every hostname lookup fails -- claude and codex both surface this as `FailedToOpenSocket` / `ConnectionRefused`, blocking the entire LLM code-review scanner the moment it tries to call an API.

Binding the symlink's resolved target directly onto `/etc/resolv.conf` doesn't work: bwrap follows the existing dangling symlink during destination creation and fails with `bwrap: Can't create file at /etc/resolv.conf: No such file or directory`. Instead, ro-bind the target's parent directory at its real path so the symlink resolves naturally without needing to overlay `/etc/resolv.conf` itself.

The bind is gated on `allow_network` so the network-isolated scanner default (`regex-secrets`, etc.) stays unaffected.