### PR TITLE
Bake Mozilla TLS roots into the loupe-server binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1370,6 +1371,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2156,6 +2158,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,11 +38,16 @@ clap = { version = "4", default-features = false, features = ["std", "derive", "
 hyper = { version = "1", default-features = false, features = ["server", "http1"] }
 hyper-util = { version = "0.1", default-features = false, features = ["tokio", "service", "server"] }
 regex = { version = "1", default-features = false, features = ["std", "perf"] }
-# `rustls-tls-manual-roots-no-provider` keeps reqwest from pinning a
-# crypto provider; we explicitly add the `ring` provider via the
-# `rustls` workspace dep below, which both reqwest and tokio-rustls
-# share. `aws-lc-rs` is excluded.
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-manual-roots", "json"] }
+# `rustls-tls-webpki-roots` gives reqwest a compiled-in Mozilla root
+# store (via the `webpki-roots` crate) so the GitHub reporter can talk
+# to api.github.com without depending on the host's `ca-certificates`
+# package. mTLS callers (worker→server, admin→server) still pin the
+# private loupe CA via `add_root_certificate`; webpki-roots are
+# additive and harmless on those paths since the loupe server cert
+# does not chain to a public root. Crypto provider is `ring`, pulled
+# in explicitly via the `rustls` workspace dep below; `aws-lc-rs` is
+# excluded.
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-webpki-roots", "json"] }
 tokio-util = { version = "0.7", default-features = false, features = ["rt"] }
 git2 = { version = "0.20", default-features = false, features = ["https"] }
 rcgen = { version = "0.13", default-features = false, features = ["crypto", "ring", "pem", "x509-parser"] }

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -21,8 +21,12 @@ ARG BKB_MCP_VERSION=0.2.0
 RUN cargo install bkb-mcp --version "${BKB_MCP_VERSION}" --locked
 
 FROM debian:bookworm-slim AS loupe-server
+# No `ca-certificates` here: loupe-server's only outbound TLS is the
+# GitHub reporter, which uses reqwest + rustls with webpki-roots
+# compiled into the binary (see workspace Cargo.toml). Sendmail is
+# local. Worker / admin mTLS pins the private loupe CA explicitly.
 RUN apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates tini \
+	&& apt-get install -y --no-install-recommends tini \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& useradd --uid 10001 --user-group --home-dir /var/lib/loupe --create-home --shell /usr/sbin/nologin loupe
 COPY --from=app-builder /src/target/release/loupe-server /usr/local/bin/loupe-server


### PR DESCRIPTION
The GithubReporter could not reach api.github.com on any deploy: the workspace pinned `reqwest` to `rustls-tls-manual-roots` (empty root store) and the reporter never added any roots, so every dispatch failed with rustls's `UnknownIssuer`. The existing dispatcher tests masked the gap by speaking plain HTTP against a stub. Switching to `rustls-tls-webpki-roots` compiles the Mozilla root set into the binary so the reporter works on any host.

`ca-certificates` was dead weight on the loupe-server runtime image (rustls with manual roots never consulted the system store) and is dropped. The worker image keeps it because `git clone` uses libcurl with the host trust store. mTLS callers still pin the private loupe CA via `add_root_certificate`; webpki-roots are additive and not exercised on those paths because the server cert chains to the private CA only.

Co-Authored-By: HAL 9000