### PR TITLE
Improve GitHub finding issue reports

### DIFF
--- a/crates/loupe-server/src/reporters/github.rs
+++ b/crates/loupe-server/src/reporters/github.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
-use loupe_core::{Finding, ReportingDestination, Severity};
+use loupe_core::{Finding, ReportingDestination};
 use loupe_storage::repos::RepoRow;
 use reqwest::Url;
 use serde::Serialize;
@@ -13,6 +13,7 @@ use serde::Serialize;
 use super::{DispatchReceipt, Reporter};
 
 const DEFAULT_API_BASE: &str = "https://api.github.com";
+const MAX_TITLE_CHARS: usize = 100;
 
 pub struct GithubReporter {
 	http: reqwest::Client,
@@ -65,73 +66,178 @@ impl Reporter for GithubReporter {
 			return Ok(DispatchReceipt { kind: self.kind(), external_id: None });
 		}
 
-		let url = self
-			.api_base
-			.join(&format!("/repos/{target_owner}/{target_repo}/issues"))
-			.map_err(|e| anyhow!("building issues URL: {e}"))?;
-		let title = render_title(repo, findings);
-		let body = render_body(repo, findings);
-		let labels = vec!["loupe".to_owned(), max_severity(findings).as_str().to_owned()];
+		let mut external_ids = Vec::new();
+		for finding in findings {
+			let url = self
+				.api_base
+				.join(&format!("/repos/{target_owner}/{target_repo}/issues"))
+				.map_err(|e| anyhow!("building issues URL: {e}"))?;
+			let title = render_title(finding);
+			let body = render_body(repo, finding);
+			let labels = vec!["loupe".to_owned(), finding.severity.as_str().to_owned()];
 
-		let resp = self
-			.http
-			.post(url)
-			.bearer_auth(pat)
-			.header("Accept", "application/vnd.github+json")
-			.header("X-GitHub-Api-Version", "2022-11-28")
-			.json(&CreateIssueBody { title: &title, body, labels })
-			.send()
-			.await
-			.context("posting github issue")?;
-		let status = resp.status();
-		if !status.is_success() {
-			let body = resp.text().await.unwrap_or_default();
-			anyhow::bail!("github returned {} when opening issue: {}", status, body);
+			let resp = self
+				.http
+				.post(url)
+				.bearer_auth(pat)
+				.header("Accept", "application/vnd.github+json")
+				.header("X-GitHub-Api-Version", "2022-11-28")
+				.json(&CreateIssueBody { title: &title, body, labels })
+				.send()
+				.await
+				.context("posting github issue")?;
+			let status = resp.status();
+			if !status.is_success() {
+				let body = resp.text().await.unwrap_or_default();
+				anyhow::bail!("github returned {} when opening issue: {}", status, body);
+			}
+			let json: serde_json::Value = resp.json().await.context("parsing issue response")?;
+			if let Some(external_id) =
+				json.get("number").and_then(|v| v.as_i64()).map(|n| n.to_string())
+			{
+				external_ids.push(external_id);
+			}
 		}
-		let json: serde_json::Value = resp.json().await.context("parsing issue response")?;
-		let external_id = json.get("number").and_then(|v| v.as_i64()).map(|n| n.to_string());
+		let external_id = (!external_ids.is_empty()).then(|| external_ids.as_slice().join(","));
 		Ok(DispatchReceipt { kind: self.kind(), external_id })
 	}
 }
 
-fn render_title(repo: &RepoRow, findings: &[Finding]) -> String {
-	let count = findings.len();
-	let max_sev = max_severity(findings);
-	format!("[loupe] {count} {max_sev} finding(s) in {}/{}", repo.owner, repo.repo)
+fn render_title(finding: &Finding) -> String {
+	format!("{}: {}", finding.severity, compact_title(&finding.title))
 }
 
-fn render_body(repo: &RepoRow, findings: &[Finding]) -> String {
+fn compact_title(raw: &str) -> String {
+	let mut compact = String::new();
+	for word in raw.split_whitespace() {
+		if !compact.is_empty() {
+			compact.push(' ');
+		}
+		compact.push_str(word);
+	}
+	if compact.is_empty() {
+		compact.push_str("Untitled finding");
+	}
+	if compact.chars().count() <= MAX_TITLE_CHARS {
+		return compact;
+	}
+
+	let mut truncated: String = compact.chars().take(MAX_TITLE_CHARS - 3).collect();
+	while truncated.ends_with(char::is_whitespace) {
+		truncated.pop();
+	}
+	truncated.push_str("...");
+	truncated
+}
+
+fn render_body(repo: &RepoRow, finding: &Finding) -> String {
 	let mut out = String::new();
 	out.push_str(&format!(
-		"loupe has finished a scan of `{}/{}` (clone url `{}`).\n\n",
+		"This issue tracks one loupe finding in `{}/{}` (clone url `{}`).\n\n",
 		repo.owner, repo.repo, repo.clone_url
 	));
-	out.push_str(&format!("**Findings: {}**\n\n", findings.len()));
-	for (i, f) in findings.iter().enumerate() {
-		out.push_str(&format!("### {}. {} ({})\n", i + 1, f.title, f.severity));
-		if let Some(path) = &f.file_path {
-			out.push_str(&format!("- file: `{path}`"));
-			if let Some(line) = f.line_start {
-				out.push_str(&format!(":{line}"));
-			}
-			out.push('\n');
-		}
-		if let Some(cwe) = &f.cwe {
-			out.push_str(&format!("- cwe: {cwe}\n"));
-		}
-		out.push_str(&format!("- scanner: `{}`\n", f.scanner_id));
-		out.push_str(&format!("- fingerprint: `{}`\n\n", f.fingerprint));
-		out.push_str(&f.description);
-		out.push_str("\n\n");
-		if let Some(patch) = &f.patch_unified {
-			out.push_str("```diff\n");
-			out.push_str(patch);
-			out.push_str("\n```\n\n");
-		}
+	out.push_str("## Finding\n\n");
+	out.push_str(&format!("- title: {}\n", finding.title));
+	out.push_str(&format!("- severity: `{}`\n", finding.severity));
+	if let Some(location) = render_location(finding) {
+		out.push_str(&format!("- location: {location}\n"));
 	}
+	if let Some(cwe) = &finding.cwe {
+		out.push_str(&format!("- cwe: {cwe}\n"));
+	}
+	out.push_str(&format!("- scanner: `{}`\n", finding.scanner_id));
+	out.push_str(&format!("- fingerprint: `{}`\n\n", finding.fingerprint));
+
+	out.push_str("## Description\n\n");
+	out.push_str(&finding.description);
+	out.push_str("\n\n");
+
+	if let Some(poc) = &finding.poc_unified {
+		out.push_str("## Proof of Concept\n\n```diff\n");
+		out.push_str(poc);
+		out.push_str("\n```\n\n");
+	}
+
+	if let Some(patch) = &finding.patch_unified {
+		out.push_str("## Suggested Fix\n\n```diff\n");
+		out.push_str(patch);
+		out.push_str("\n```\n\n");
+	}
+
 	out
 }
 
-fn max_severity(findings: &[Finding]) -> Severity {
-	findings.iter().map(|f| f.severity).max().unwrap_or(Severity::Info)
+fn render_location(finding: &Finding) -> Option<String> {
+	let path = finding.file_path.as_ref()?;
+	let suffix = match (finding.line_start, finding.line_end) {
+		(Some(start), Some(end)) if end != start => format!(":{start}-{end}"),
+		(Some(start), _) => format!(":{start}"),
+		_ => String::new(),
+	};
+	Some(format!("`{path}{suffix}`"))
+}
+
+#[cfg(test)]
+mod tests {
+	use loupe_core::Severity;
+
+	use super::*;
+
+	fn repo() -> RepoRow {
+		RepoRow {
+			id: 1,
+			clone_url: "https://github.com/acme/widget.git".into(),
+			host: "github.com".into(),
+			owner: "acme".into(),
+			repo: "widget".into(),
+			default_branch: None,
+			scan_interval_seconds: None,
+			scanner_config: serde_json::Value::Null,
+			reporting: ReportingDestination::GithubIssue {
+				target_owner: "acme".into(),
+				target_repo: "tracker".into(),
+				pat_secret_id: 7,
+			},
+			verification_enabled: false,
+			require_approval: None,
+			last_scanned_sha: None,
+			last_scanned_at: None,
+			created_at: 0,
+			disabled_at: None,
+		}
+	}
+
+	fn finding() -> Finding {
+		Finding {
+			scanner_id: "llm-code-review".into(),
+			severity: Severity::High,
+			title: "Out-of-bounds index in idx".into(),
+			description: "The idx helper indexes without checking bounds.".into(),
+			file_path: Some("src/lib.rs".into()),
+			line_start: Some(4),
+			line_end: Some(6),
+			cwe: Some("CWE-129".into()),
+			patch_unified: Some("--- a/src/lib.rs\n+++ b/src/lib.rs\n".into()),
+			poc_unified: Some("--- a/src/lib.rs\n+++ b/src/lib.rs\n".into()),
+			fingerprint: "fp".into(),
+		}
+	}
+
+	#[test]
+	fn title_is_per_finding_without_loupe_prefix() {
+		assert_eq!(render_title(&finding()), "high: Out-of-bounds index in idx");
+	}
+
+	#[test]
+	fn body_describes_one_finding_not_a_scan_batch() {
+		let body = render_body(&repo(), &finding());
+		assert!(body.contains("This issue tracks one loupe finding"));
+		assert!(body.contains("- title: Out-of-bounds index in idx"));
+		assert!(body.contains("- severity: `high`"));
+		assert!(body.contains("- location: `src/lib.rs:4-6`"));
+		assert!(body.contains("## Proof of Concept"));
+		assert!(body.contains("## Suggested Fix"));
+		assert!(!body.contains("finished a scan"));
+		assert!(!body.contains("Findings:"));
+	}
 }

--- a/crates/loupe-server/src/routes/jobs.rs
+++ b/crates/loupe-server/src/routes/jobs.rs
@@ -704,7 +704,6 @@ async fn dispatch_confirmed_rows(
 		return Ok(());
 	}
 	let ids: Vec<i64> = confirmed_rows.iter().map(|r| r.id).collect();
-	let findings_for_report: Vec<_> = confirmed_rows.into_iter().map(finding_from_row).collect();
 
 	if matches!(repo.reporting, ReportingDestination::Manual) {
 		match scope {
@@ -725,6 +724,32 @@ async fn dispatch_confirmed_rows(
 	let reporter =
 		reporters::select(repo, state.github_reporter.clone(), state.email_reporter.clone())
 			.ok_or_else(|| anyhow::anyhow!("no reporter for destination kind"))?;
+
+	if matches!(repo.reporting, ReportingDestination::GithubIssue { .. }) {
+		for row in confirmed_rows {
+			let finding_id = row.id;
+			let finding = finding_from_row(row);
+			let findings_for_report = [finding];
+			let receipt = reporter.dispatch(repo, &findings_for_report, &pat).await?;
+			match scope {
+				DispatchScope::Finding(_) => tracing::info!(
+					finding_id,
+					external_id = receipt.external_id.as_deref(),
+					"dispatched finding"
+				),
+				DispatchScope::Job(job_id) => tracing::info!(
+					job_id,
+					finding_id,
+					external_id = receipt.external_id.as_deref(),
+					"dispatched finding"
+				),
+			}
+			mark_reported(state, &[finding_id], now)?;
+		}
+		return Ok(());
+	}
+
+	let findings_for_report: Vec<_> = confirmed_rows.into_iter().map(finding_from_row).collect();
 	let receipt = reporter.dispatch(repo, &findings_for_report, &pat).await?;
 	match scope {
 		DispatchScope::Finding(finding_id) => tracing::info!(

--- a/crates/loupe-server/tests/dispatch.rs
+++ b/crates/loupe-server/tests/dispatch.rs
@@ -350,9 +350,25 @@ async fn dispatch_only_marks_confirmed_findings_reported() {
 		poc_unified: None,
 		fingerprint: "confirmed-fp".into(),
 	};
+	let second_confirmed = Finding {
+		scanner_id: "test".into(),
+		severity: Severity::Critical,
+		title: "Second confirmed finding with a direct title".into(),
+		description: "This one should be dispatched separately".into(),
+		file_path: Some("src/critical.rs".into()),
+		line_start: Some(9),
+		line_end: Some(11),
+		cwe: None,
+		patch_unified: None,
+		poc_unified: None,
+		fingerprint: "second-confirmed-fp".into(),
+	};
 	let resp = worker
 		.post(format!("https://loupe-server/v1/jobs/{}/findings", env.job_id))
-		.json(&FindingsBatch { protocol_version: PROTOCOL_VERSION, findings: vec![confirmed] })
+		.json(&FindingsBatch {
+			protocol_version: PROTOCOL_VERSION,
+			findings: vec![confirmed, second_confirmed],
+		})
 		.send()
 		.await
 		.unwrap();
@@ -415,10 +431,19 @@ async fn dispatch_only_marks_confirmed_findings_reported() {
 		states,
 		vec![
 			("confirmed-fp".to_owned(), "reported".to_owned()),
+			("second-confirmed-fp".to_owned(), "reported".to_owned()),
 			("validating-fp".to_owned(), "validating".to_owned()),
 		]
 	);
-	assert_eq!(stub_state.captured.lock().unwrap().len(), 1);
+	let captured = stub_state.captured.lock().unwrap().clone();
+	assert_eq!(captured.len(), 2);
+	let titles: Vec<_> =
+		captured.iter().map(|issue| issue.body["title"].as_str().unwrap_or("")).collect();
+	assert_eq!(
+		titles,
+		vec!["high: Confirmed finding", "critical: Second confirmed finding with a direct title"]
+	);
+	assert!(titles.iter().all(|title| !title.contains("[loupe]")), "titles: {titles:?}");
 
 	server.shutdown().await;
 }

--- a/crates/loupe-server/tests/llm_dispatch.rs
+++ b/crates/loupe-server/tests/llm_dispatch.rs
@@ -272,9 +272,10 @@ async fn llm_scanner_full_pipeline_dispatches_via_github() {
 	assert_eq!(issue.repo, "tracker");
 	let issue_body = issue.body["body"].as_str().unwrap_or("");
 	let issue_title = issue.body["title"].as_str().unwrap_or("");
-	assert!(issue_title.contains("high finding"), "title: {issue_title}");
+	assert_eq!(issue_title, "high: Out-of-bounds index in idx");
 	assert!(issue_body.contains("Out-of-bounds index"), "body: {issue_body}");
 	assert!(issue_body.contains("llm-code-review"), "body: {issue_body}");
+	assert!(issue_body.contains("#[test] fn oob_panic"), "body: {issue_body}");
 
 	server.shutdown().await;
 }

--- a/crates/loupe-server/tests/verify_flow.rs
+++ b/crates/loupe-server/tests/verify_flow.rs
@@ -341,7 +341,7 @@ async fn confirmed_verdict_dispatches_the_finding() {
 	// GitHub stub captured exactly one issue.
 	let captured = stub.captured.lock().unwrap().clone();
 	assert_eq!(captured.len(), 1);
-	assert!(captured[0]["title"].as_str().unwrap().contains("high finding"));
+	assert_eq!(captured[0]["title"].as_str().unwrap(), "high: OOB index");
 
 	server.shutdown().await;
 }


### PR DESCRIPTION
GitHub reports now create one issue per finding with titles that lead with severity and the finding title, so tracker queues are easier to triage and no longer read like scan-run summaries.

Issue bodies now describe a single finding and include the PoC/suggested-fix diffs when present, matching how operators review individual reports.

Co-Authored-By: HAL 9000