### PR TITLE
Add configurable verification defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,10 @@ The worker also probes for `bwrap` at startup and exits 1 if it is
 missing (set `LOUPE_DISABLE_SANDBOX=1` to bypass for dev work).
 Cache size defaults to 40 GB and evicts LRU clones above the cap.
 
-Verifier jobs only get queued when a repo is registered with
-`--verification-enabled`.
+Verifier jobs only get queued when a repo resolves to
+`verification_enabled = true`, either because it was registered with
+`--verification-enabled` or because the server's verification default
+is on.
 
 #### Deploy with containers
 
@@ -296,6 +298,11 @@ loupectl repo add \
 loupectl repo list
 loupectl repo scan 1                 # one-shot scan of repo id 1
 ```
+
+Add `--verification-enabled` if this repo should route scan findings
+through verifier jobs before reporting. If the server-wide verification
+default is on, omit it to inherit the default, or pass
+`--no-verification` to opt this repo out.
 
 Confirmed findings dispatch automatically — the GitHub reporter
 reads the PAT out of the secrets table (transparently decrypted by
@@ -460,13 +467,25 @@ verifier-issued `dismiss` and a human `reject` both land on
 
 Setting `verification_enabled = true` on a repo causes scan-time
 findings to land in `validating` state with one `kind=verify` job
-enqueued per finding. The verify job is leased by a worker advertising
-a `verify:*` capability, which runs an independent LLM pass over the
-finding and submits a `confirm | dismiss | inconclusive` verdict. The
-server applies a rollup policy in-transaction (any `dismissed` →
-finding `dismissed`; else any `confirmed` → `confirmed` + dispatch;
-else stay in `validating`). The full state machine + reaper details
-are in `ARCH.md` and the `submit_verdict` / `complete` handlers in
+enqueued per finding. You can set it per repo with
+`loupectl repo add --verification-enabled` or
+`loupectl repo update <id> --verification-enabled`.
+
+For verifier-first deployments, set the server-wide
+`verification_default` in `config.toml`'s `[policy]` section,
+or pass `--verification-default` / set
+`LOUPE_VERIFICATION_DEFAULT=true`. New repo registrations that
+do not pass either `--verification-enabled` or `--no-verification`
+inherit that default. Existing repos keep their stored value; update
+them explicitly if you change the server default later.
+
+The verify job is leased by a worker advertising a `verify:*`
+capability, which runs an independent LLM pass over the finding and
+submits a `confirm | dismiss | inconclusive` verdict. The server
+applies a rollup policy in-transaction (any `dismissed` → finding
+`dismissed`; else any `confirmed` → `confirmed` + dispatch; else stay
+in `validating`). The full state machine + reaper details are in
+`ARCH.md` and the `submit_verdict` / `complete` handlers in
 `crates/loupe-server/src/routes/jobs.rs`.
 
 A worker with `codex` (or just `claude`) on PATH advertises

--- a/contrib/config.toml
+++ b/contrib/config.toml
@@ -41,3 +41,15 @@ master_key  = "master.key"
 #
 # Default when unset: false (immediate dispatch).
 require_approval_default = false
+
+# Server-wide default for routing new repo registrations through the
+# verifier flow. When `true`, repos added without `--verification-enabled`
+# or `--no-verification` inherit verifier-first reporting. Existing repos
+# keep the value resolved when they were registered; use
+# `loupectl repo update <id> --verification-enabled/--no-verification`
+# to change them later.
+#
+# Default when unset: false (skip verify; dispatch confirmed findings).
+# This sample enables it because production deployments should usually
+# report only after the verifier confirms a finding.
+verification_default = true

--- a/contrib/docker/deploy-server.sh
+++ b/contrib/docker/deploy-server.sh
@@ -84,7 +84,14 @@ build_conf_file() {
 		write_conf_var LOUPE_SECRET_FILE "$REMOTE_SECRET"
 		write_conf_var LOUPE_SERVER_DATA_DIR "${LOUPE_SERVER_DATA_DIR:-/var/lib/loupe-container/server}"
 		write_conf_var LOUPE_SERVER_PUBLISH "${LOUPE_SERVER_PUBLISH:-8443:8443}"
-		for name in RUST_LOG LOUPE_LOG_JSON LOUPE_BIND LOUPE_DB LOUPE_REQUIRE_APPROVAL_DEFAULT; do
+		for name in \
+			RUST_LOG \
+			LOUPE_LOG_JSON \
+			LOUPE_BIND \
+			LOUPE_DB \
+			LOUPE_REQUIRE_APPROVAL_DEFAULT \
+			LOUPE_VERIFICATION_DEFAULT
+		do
 			if [ -n "${!name+x}" ]; then
 				write_conf_var "$name" "${!name}"
 			fi

--- a/contrib/docker/run-server-container.sh
+++ b/contrib/docker/run-server-container.sh
@@ -22,7 +22,14 @@ fi
 install -d -o 10001 -g 10001 -m 0700 "$DATA_DIR"
 
 env_args=()
-for name in RUST_LOG LOUPE_LOG_JSON LOUPE_BIND LOUPE_DB LOUPE_REQUIRE_APPROVAL_DEFAULT; do
+for name in \
+	RUST_LOG \
+	LOUPE_LOG_JSON \
+	LOUPE_BIND \
+	LOUPE_DB \
+	LOUPE_REQUIRE_APPROVAL_DEFAULT \
+	LOUPE_VERIFICATION_DEFAULT
+do
 	if [ -n "${!name+x}" ]; then
 		env_args+=(--env "$name=${!name}")
 	fi

--- a/crates/loupe-cli/src/main.rs
+++ b/crates/loupe-cli/src/main.rs
@@ -181,11 +181,14 @@ struct RepoAddArgs {
 		conflicts_with_all = ["target_owner", "target_repo", "pat"],
 	)]
 	no_reporting: bool,
-	/// Route findings through the verify flow before dispatching. Off
-	/// by default; turn on for repos where you want a second-opinion
-	/// verifier worker to confirm each finding.
-	#[arg(long, default_value_t = false)]
+	/// Route findings through the verify flow before dispatching.
+	#[arg(long, conflicts_with = "no_verification")]
 	verification_enabled: bool,
+	/// Pin verification off for this repo, even if the server default
+	/// is on. If neither flag is set, repo registration inherits the
+	/// server-level verification default.
+	#[arg(long, conflicts_with = "verification_enabled")]
+	no_verification: bool,
 	/// Pin per-repo require_approval = true at registration time.
 	#[arg(long, conflicts_with = "no_require_approval")]
 	require_approval: bool,
@@ -451,6 +454,11 @@ async fn repo_add(client: &reqwest::Client, base: &reqwest::Url, a: RepoAddArgs)
 		(false, true) => Some(false),
 		_ => None,
 	};
+	let verification_enabled = match (a.verification_enabled, a.no_verification) {
+		(true, false) => Some(true),
+		(false, true) => Some(false),
+		_ => None,
+	};
 	let reporting = if a.no_reporting {
 		ReportingSetup::Manual
 	} else {
@@ -469,7 +477,7 @@ async fn repo_add(client: &reqwest::Client, base: &reqwest::Url, a: RepoAddArgs)
 		scan_interval_seconds: a.scan_interval_seconds,
 		reporting,
 		scanner_config: serde_json::Value::Null,
-		verification_enabled: a.verification_enabled,
+		verification_enabled,
 		require_approval,
 	};
 	let resp = client.post(url(base, "/v1/repos")).json(&req).send().await?;
@@ -859,6 +867,45 @@ mod tests {
 		};
 		assert_eq!(args.id, 7);
 		assert_eq!(args.pat, "ghp_replacement");
+	}
+
+	#[test]
+	fn repo_add_inherits_verification_default_unless_pinned() {
+		let base = [
+			"loupectl",
+			"--server-url",
+			"https://loupe.example:8443",
+			"repo",
+			"add",
+			"--clone-url",
+			"https://github.com/acme/widget.git",
+			"--no-reporting",
+		];
+
+		let cli = Cli::try_parse_from(base).unwrap();
+		let Cmd::Repo(RepoCmd::Add(args)) = cli.cmd else {
+			panic!("expected repo add command");
+		};
+		assert!(!args.verification_enabled);
+		assert!(!args.no_verification);
+
+		let mut with_verify = base.to_vec();
+		with_verify.push("--verification-enabled");
+		let cli = Cli::try_parse_from(with_verify).unwrap();
+		let Cmd::Repo(RepoCmd::Add(args)) = cli.cmd else {
+			panic!("expected repo add command");
+		};
+		assert!(args.verification_enabled);
+		assert!(!args.no_verification);
+
+		let mut without_verify = base.to_vec();
+		without_verify.push("--no-verification");
+		let cli = Cli::try_parse_from(without_verify).unwrap();
+		let Cmd::Repo(RepoCmd::Add(args)) = cli.cmd else {
+			panic!("expected repo add command");
+		};
+		assert!(!args.verification_enabled);
+		assert!(args.no_verification);
 	}
 
 	#[test]

--- a/crates/loupe-proto/src/registry.rs
+++ b/crates/loupe-proto/src/registry.rs
@@ -44,12 +44,12 @@ pub struct RegisterRepoRequest {
 	pub reporting: ReportingSetup,
 	#[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
 	pub scanner_config: serde_json::Value,
-	/// When `true`, scan findings for this repo go through the verify
-	/// flow before being dispatched. Defaults to `false` so simple
-	/// scanners that don't have a verifier worker pool to back them
-	/// dispatch immediately.
-	#[serde(default)]
-	pub verification_enabled: bool,
+	/// Per-repo override of the verify flow. `None` (the default on
+	/// the wire) means "inherit the server's
+	/// `verification_default`". `Some(true)` / `Some(false)`
+	/// pin the value for this repo regardless of the server default.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub verification_enabled: Option<bool>,
 	/// Per-repo override of the human-in-the-loop approval gate. `None`
 	/// (the default on the wire) means "inherit the server's
 	/// `require_approval_default`". `Some(true)` / `Some(false)` pin
@@ -67,7 +67,7 @@ impl RegisterRepoRequest {
 			scan_interval_seconds: None,
 			reporting,
 			scanner_config: serde_json::Value::Null,
-			verification_enabled: false,
+			verification_enabled: None,
 			require_approval: None,
 		}
 	}
@@ -191,7 +191,7 @@ mod tests {
 				github_pat: "ghp_xxx".into(),
 			},
 			scanner_config: json!({"regex": {"enabled": true}}),
-			verification_enabled: true,
+			verification_enabled: Some(true),
 			require_approval: Some(false),
 		};
 		let s = serde_json::to_string(&req).unwrap();
@@ -199,6 +199,19 @@ mod tests {
 		assert_eq!(req, back);
 		// Sanity check: the wire form does not leak `pat_secret_id`.
 		assert!(!s.contains("pat_secret_id"));
+	}
+
+	#[test]
+	fn register_repo_request_omits_inherited_verification_default() {
+		let req =
+			RegisterRepoRequest::new("https://github.com/acme/widget.git", ReportingSetup::Manual);
+		let s = serde_json::to_string(&req).unwrap();
+		assert!(
+			!s.contains("verification_enabled"),
+			"verification default should be inherited unless pinned: {s}"
+		);
+		let back: RegisterRepoRequest = serde_json::from_str(&s).unwrap();
+		assert_eq!(back.verification_enabled, None);
 	}
 
 	#[test]

--- a/crates/loupe-server/src/config.rs
+++ b/crates/loupe-server/src/config.rs
@@ -75,6 +75,13 @@ pub struct PolicySection {
 	/// here AND unset on the repo.
 	#[serde(default)]
 	pub require_approval_default: Option<bool>,
+	/// Server-level default for routing scan findings through verifier
+	/// jobs before dispatch. Repo registrations can override this
+	/// explicitly; existing repos keep the value resolved at
+	/// registration time.
+	#[serde(default)]
+	#[serde(alias = "verification_enabled_default")]
+	pub verification_default: Option<bool>,
 }
 
 impl FileConfig {
@@ -119,6 +126,7 @@ mod tests {
 		let cfg = FileConfig::load(&path).unwrap();
 		assert!(cfg.server.bind.is_none());
 		assert!(cfg.policy.require_approval_default.is_none());
+		assert!(cfg.policy.verification_default.is_none());
 	}
 
 	#[test]
@@ -152,8 +160,13 @@ mod tests {
 	fn policy_section_round_trips() {
 		let dir = tempfile::tempdir().unwrap();
 		let path = dir.path().join("config.toml");
-		std::fs::write(&path, b"[policy]\nrequire_approval_default = true\n").unwrap();
+		std::fs::write(
+			&path,
+			b"[policy]\nrequire_approval_default = true\nverification_default = true\n",
+		)
+		.unwrap();
 		let cfg = FileConfig::load(&path).unwrap();
 		assert_eq!(cfg.policy.require_approval_default, Some(true));
+		assert_eq!(cfg.policy.verification_default, Some(true));
 	}
 }

--- a/crates/loupe-server/src/main.rs
+++ b/crates/loupe-server/src/main.rs
@@ -115,6 +115,11 @@ struct ServeArgs {
 	/// (immediate dispatch).
 	#[arg(long, env = "LOUPE_REQUIRE_APPROVAL_DEFAULT")]
 	require_approval_default: Option<bool>,
+	/// Server-level default for the verify flow. Repo registration can
+	/// explicitly opt in or out. When unset here and in the config file,
+	/// the default is `false` (dispatch without verifier jobs).
+	#[arg(long, env = "LOUPE_VERIFICATION_DEFAULT")]
+	verification_default: Option<bool>,
 }
 
 #[tokio::main]
@@ -212,6 +217,8 @@ async fn run_serve(args: ServeArgs) -> Result<()> {
 		.context("db path missing — pass --db, set LOUPE_DB, or [paths].db in config.toml")?;
 	let require_approval_default =
 		args.require_approval_default.or(file_cfg.policy.require_approval_default).unwrap_or(false);
+	let verification_default =
+		args.verification_default.or(file_cfg.policy.verification_default).unwrap_or(false);
 
 	// Master key resolution: env > --master-key-file flag > [paths]
 	// master_key in config.toml. The env-var path is the highest
@@ -275,10 +282,16 @@ async fn run_serve(args: ServeArgs) -> Result<()> {
 		.with_context(|| format!("opening db at {}", db_path.display()))?;
 	let github = Arc::new(loupe_server::reporters::GithubReporter::new()?);
 	let state = AppState::new(Arc::new(db), Arc::new(ca), github)
-		.with_require_approval_default(require_approval_default);
+		.with_require_approval_default(require_approval_default)
+		.with_verification_default(verification_default);
 	if require_approval_default {
 		tracing::info!(
 			"loupe-server: require_approval_default = true (per-repo overrides may opt out)"
+		);
+	}
+	if verification_default {
+		tracing::info!(
+			"loupe-server: verification_default = true (repo registrations may opt out)"
 		);
 	}
 

--- a/crates/loupe-server/src/routes/repos.rs
+++ b/crates/loupe-server/src/routes/repos.rs
@@ -89,7 +89,9 @@ pub async fn create(
 					scan_interval_seconds: req.scan_interval_seconds.map(|v| v as i64),
 					scanner_config: req.scanner_config.clone(),
 					reporting,
-					verification_enabled: req.verification_enabled,
+					verification_enabled: req
+						.verification_enabled
+						.unwrap_or(state.verification_default),
 					require_approval: req.require_approval,
 				},
 				now,

--- a/crates/loupe-server/src/state.rs
+++ b/crates/loupe-server/src/state.rs
@@ -29,6 +29,11 @@ pub struct AppState {
 	/// default — i.e. the operator didn't pin a per-repo override).
 	/// `false` keeps the existing immediate-dispatch behaviour.
 	pub require_approval_default: bool,
+	/// Server-wide default for the verify flow. Used when a repo
+	/// registration omits `verification_enabled`; the resolved value is
+	/// stored on the repo row so later server config changes do not
+	/// silently change existing repos.
+	pub verification_default: bool,
 }
 
 impl AppState {
@@ -40,6 +45,7 @@ impl AppState {
 			email_reporter: Arc::new(EmailReporter::new()),
 			job_arrived: Arc::new(Notify::new()),
 			require_approval_default: false,
+			verification_default: false,
 		}
 	}
 
@@ -50,6 +56,11 @@ impl AppState {
 
 	pub fn with_require_approval_default(mut self, on: bool) -> Self {
 		self.require_approval_default = on;
+		self
+	}
+
+	pub fn with_verification_default(mut self, on: bool) -> Self {
+		self.verification_default = on;
 		self
 	}
 }

--- a/crates/loupe-server/tests/approval_flow.rs
+++ b/crates/loupe-server/tests/approval_flow.rs
@@ -182,7 +182,7 @@ async fn register_with(
 			scan_interval_seconds: None,
 			reporting,
 			scanner_config: serde_json::Value::Null,
-			verification_enabled: false,
+			verification_enabled: Some(false),
 			require_approval,
 		})
 		.send()

--- a/crates/loupe-server/tests/dispatch.rs
+++ b/crates/loupe-server/tests/dispatch.rs
@@ -148,7 +148,7 @@ async fn dispatcher_opens_a_github_issue_after_a_succeeded_scan() {
 				github_pat: "ghp_test_pat_value".into(),
 			},
 			scanner_config: serde_json::Value::Null,
-			verification_enabled: false,
+			verification_enabled: Some(false),
 			require_approval: None,
 		})
 		.send()
@@ -287,7 +287,7 @@ async fn dispatch_only_marks_confirmed_findings_reported() {
 				github_pat: "ghp_test_pat_value".into(),
 			},
 			scanner_config: serde_json::Value::Null,
-			verification_enabled: false,
+			verification_enabled: Some(false),
 			require_approval: None,
 		})
 		.send()

--- a/crates/loupe-server/tests/email_dispatch.rs
+++ b/crates/loupe-server/tests/email_dispatch.rs
@@ -110,7 +110,7 @@ async fn email_reporter_invokes_sendmail_with_findings() {
 				subject_prefix: Some("[scan]".into()),
 			},
 			scanner_config: serde_json::Value::Null,
-			verification_enabled: false,
+			verification_enabled: Some(false),
 			require_approval: None,
 		})
 		.send()

--- a/crates/loupe-server/tests/jobs.rs
+++ b/crates/loupe-server/tests/jobs.rs
@@ -87,7 +87,7 @@ async fn bring_up_with_repo_and_worker() -> Fixture {
 			github_pat: "ghp".into(),
 		},
 		scanner_config: serde_json::Value::Null,
-		verification_enabled: false,
+		verification_enabled: Some(false),
 		require_approval: None,
 	};
 	let resp = admin.post("https://loupe-server/v1/repos").json(&req).send().await.unwrap();
@@ -121,7 +121,7 @@ async fn register_repo(f: &Fixture, clone_url: &str, target_repo: &str) -> i64 {
 			github_pat: "ghp".into(),
 		},
 		scanner_config: serde_json::Value::Null,
-		verification_enabled: false,
+		verification_enabled: Some(false),
 		require_approval: None,
 	};
 	let resp = f.admin.post("https://loupe-server/v1/repos").json(&req).send().await.unwrap();

--- a/crates/loupe-server/tests/llm_dispatch.rs
+++ b/crates/loupe-server/tests/llm_dispatch.rs
@@ -150,7 +150,7 @@ async fn llm_scanner_full_pipeline_dispatches_via_github() {
 				github_pat: "ghp_pat".into(),
 			},
 			scanner_config: serde_json::Value::Null,
-			verification_enabled: false,
+			verification_enabled: Some(false),
 			require_approval: None,
 		})
 		.send()

--- a/crates/loupe-server/tests/repos.rs
+++ b/crates/loupe-server/tests/repos.rs
@@ -41,6 +41,10 @@ struct Fixture {
 }
 
 async fn bring_up() -> Fixture {
+	bring_up_with_verification_default(false).await
+}
+
+async fn bring_up_with_verification_default(verification_default: bool) -> Fixture {
 	let tmp = tempfile::tempdir().unwrap();
 	let init = run_init(tmp.path(), &["loupe-server".to_owned()], None).unwrap();
 
@@ -70,7 +74,8 @@ async fn bring_up() -> Fixture {
 		db.clone(),
 		Arc::new(ca),
 		Arc::new(loupe_server::reporters::GithubReporter::new().unwrap()),
-	);
+	)
+	.with_verification_default(verification_default);
 	let handle = serve(cfg, state).await.unwrap();
 	let addr = handle.local_addr;
 	std::mem::forget(tmp);
@@ -86,7 +91,7 @@ async fn create_repo(admin: &reqwest::Client, reporting: ReportingSetup) -> i64 
 		scan_interval_seconds: Some(3600),
 		reporting,
 		scanner_config: serde_json::json!({"regex": {"enabled": true}}),
-		verification_enabled: true,
+		verification_enabled: Some(true),
 		require_approval: Some(false),
 	};
 	let resp = admin.post("https://loupe-server/v1/repos").json(&req).send().await.unwrap();
@@ -131,7 +136,7 @@ async fn admin_can_register_list_and_delete_a_repo() {
 			github_pat: "ghp_secret_value".into(),
 		},
 		scanner_config: serde_json::json!({"regex": {"enabled": true}}),
-		verification_enabled: true,
+		verification_enabled: Some(true),
 		require_approval: Some(false),
 	};
 	let resp = admin.post("https://loupe-server/v1/repos").json(&req).send().await.unwrap();
@@ -189,6 +194,49 @@ async fn admin_can_register_list_and_delete_a_repo() {
 	let resp = admin.get("https://loupe-server/v1/repos").send().await.unwrap();
 	let body: ListReposResponse = resp.json().await.unwrap();
 	assert!(body.repos.is_empty());
+
+	f.handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn repo_registration_inherits_verification_default_unless_pinned() {
+	let f = bring_up_with_verification_default(true).await;
+	let admin = admin_client(&f.ca_cert_pem, &f.admin_cert_pem, &f.admin_key_pem, f.addr);
+
+	let inherited = RegisterRepoRequest {
+		protocol_version: PROTOCOL_VERSION,
+		clone_url: "https://github.com/acme/inherit.git".into(),
+		branch: None,
+		scan_interval_seconds: None,
+		reporting: ReportingSetup::Manual,
+		scanner_config: serde_json::Value::Null,
+		verification_enabled: None,
+		require_approval: None,
+	};
+	let resp = admin.post("https://loupe-server/v1/repos").json(&inherited).send().await.unwrap();
+	assert_eq!(resp.status(), 201, "create inherited repo: {}", resp.status());
+
+	let pinned = RegisterRepoRequest {
+		protocol_version: PROTOCOL_VERSION,
+		clone_url: "https://github.com/acme/pinned.git".into(),
+		branch: None,
+		scan_interval_seconds: None,
+		reporting: ReportingSetup::Manual,
+		scanner_config: serde_json::Value::Null,
+		verification_enabled: Some(false),
+		require_approval: None,
+	};
+	let resp = admin.post("https://loupe-server/v1/repos").json(&pinned).send().await.unwrap();
+	assert_eq!(resp.status(), 201, "create pinned repo: {}", resp.status());
+
+	let resp = admin.get("https://loupe-server/v1/repos").send().await.unwrap();
+	assert!(resp.status().is_success());
+	let body: ListReposResponse = resp.json().await.unwrap();
+	let inherited =
+		body.repos.iter().find(|repo| repo.repo == "inherit").expect("inherited repo listed");
+	let pinned = body.repos.iter().find(|repo| repo.repo == "pinned").expect("pinned repo listed");
+	assert!(inherited.verification_enabled);
+	assert!(!pinned.verification_enabled);
 
 	f.handle.shutdown().await;
 }
@@ -343,7 +391,7 @@ async fn registering_with_non_https_clone_url_400s() {
 				github_pat: "ghp".into(),
 			},
 			scanner_config: serde_json::Value::Null,
-			verification_enabled: false,
+			verification_enabled: Some(false),
 			require_approval: None,
 		};
 		let resp = admin.post("https://loupe-server/v1/repos").json(&req).send().await.unwrap();

--- a/crates/loupe-server/tests/verify_flow.rs
+++ b/crates/loupe-server/tests/verify_flow.rs
@@ -185,7 +185,7 @@ async fn run_flow(
 				github_pat: "ghp_pat".into(),
 			},
 			scanner_config: serde_json::Value::Null,
-			verification_enabled: true,
+			verification_enabled: Some(true),
 			require_approval: None,
 		})
 		.send()

--- a/crates/loupe-worker/tests/end_to_end.rs
+++ b/crates/loupe-worker/tests/end_to_end.rs
@@ -108,7 +108,7 @@ async fn worker_runs_a_scan_and_emits_a_finding() {
 				github_pat: "ghp".into(),
 			},
 			scanner_config: serde_json::Value::Null,
-			verification_enabled: false,
+			verification_enabled: Some(false),
 			require_approval: None,
 		})
 		.send()


### PR DESCRIPTION
Repo registration can now inherit a server-level verification default, so deployments that want verifier-first reporting do not have to remember --verification-enabled for every new repo.

Existing database rows remain unchanged: the server resolves the default during registration and stores the same per-repo verification_enabled boolean as before. The sample config enables verifier-first reporting for production-oriented setups.

Co-Authored-By: HAL 9000