### PR TITLE
Document LLM scan usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ startup and wires the LLM scanners accordingly:
   fall into by accident; install at least one agent CLI and provide
   its API key or login state.
 
-> **LLM usage warning:** scan jobs may consume paid, metered, or
-> rate-limited LLM usage. The discovery scanner currently uses
+> **Note:** scan jobs use LLM providers and may count against paid,
+> metered, or rate-limited usage. The discovery scanner currently uses
 > `claude-cli` and can launch one Claude agent session per discovered
 > source file, so large repositories may trigger hundreds or thousands
 > of Claude CLI invocations. `codex` is used for verifier jobs after a

--- a/README.md
+++ b/README.md
@@ -265,6 +265,16 @@ startup and wires the LLM scanners accordingly:
   fall into by accident; install at least one agent CLI and provide
   its API key or login state.
 
+> **LLM usage warning:** scan jobs may consume paid, metered, or
+> rate-limited LLM usage. The discovery scanner currently uses
+> `claude-cli` and can launch one Claude agent session per discovered
+> source file, so large repositories may trigger hundreds or thousands
+> of Claude CLI invocations. `codex` is used for verifier jobs after a
+> finding already exists. Actual cost or quota impact depends on the
+> provider, model, account plan, retries, failed-call accounting, and
+> token usage. Run a small test repository or narrow scanner
+> configuration first if usage limits matter.
+
 The worker also probes for `bwrap` at startup and exits 1 if it is
 missing (set `LOUPE_DISABLE_SANDBOX=1` to bypass for dev work).
 Cache size defaults to 40 GB and evicts LRU clones above the cap.


### PR DESCRIPTION
> **LLM usage warning:** scan jobs may consume paid, metered, or
> rate-limited LLM usage. The discovery scanner currently uses
> `claude-cli` and can launch one Claude agent session per discovered
> source file, so large repositories may trigger hundreds or thousands
> of Claude CLI invocations. `codex` is used for verifier jobs after a
> finding already exists. Actual cost or quota impact depends on the
> provider, model, account plan, retries, failed-call accounting, and
> token usage. Run a small test repository or narrow scanner
> configuration first if usage limits matter.