### PR TITLE
Allow operators to request larger list results

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,10 +380,11 @@ Reject still moves a held finding to terminal `dismissed`.
 ### 7. Inspect what happened
 
 ```
-loupectl job list
+loupectl repo list [-n <limit>]
+loupectl job list [-n <limit>]
 loupectl job get  <job-id>
 loupectl job retry <job-id>                # requeue a failed job
-loupectl finding list <repo-id>
+loupectl finding list <repo-id> [-n <limit>] # default limit is 100
 loupectl finding show <finding-id>          # pretty-printed for human review
 loupectl finding show <finding-id> --json   # raw FindingDetail DTO
 loupectl finding search <repo-id> "<keywords>"  # FTS5 keyword search

--- a/crates/loupe-cli/src/main.rs
+++ b/crates/loupe-cli/src/main.rs
@@ -68,7 +68,7 @@ enum RepoCmd {
 	/// Register a new repo for scanning.
 	Add(RepoAddArgs),
 	/// List registered repos.
-	List,
+	List(ListArgs),
 	/// Deregister a repo (cascades to its jobs and findings).
 	Rm { id: i64 },
 	/// Patch a repo's scheduling / verification settings. Each flag is
@@ -221,7 +221,7 @@ struct WorkerRegisterArgs {
 #[derive(Debug, Subcommand)]
 enum JobCmd {
 	/// List jobs with the newest row printed last.
-	List,
+	List(ListArgs),
 	Get {
 		id: i64,
 	},
@@ -238,7 +238,7 @@ enum JobCmd {
 #[derive(Debug, Subcommand)]
 enum FindingCmd {
 	/// List recent findings for a repo (recent page, newest row printed last).
-	List { repo_id: i64 },
+	List(FindingListArgs),
 	/// FTS5 keyword search over a repo's findings (title, description,
 	/// file path). Free-form keywords are sanitized server-side; the
 	/// match is "every term must appear" with BM25 ranking. Useful for
@@ -272,6 +272,29 @@ enum FindingCmd {
 	/// it to terminal `dismissed` with the rejection audit trail
 	/// stamped (distinct from a verifier-issued dismiss).
 	Reject { id: i64 },
+}
+
+#[derive(Debug, Args)]
+struct ListArgs {
+	/// Number of rows to return.
+	#[arg(short = 'n', long = "limit", value_parser = parse_positive_i64)]
+	limit: Option<i64>,
+}
+
+#[derive(Debug, Args)]
+struct FindingListArgs {
+	repo_id: i64,
+	/// Number of rows to return.
+	#[arg(short = 'n', long = "limit", value_parser = parse_positive_i64)]
+	limit: Option<i64>,
+}
+
+fn parse_positive_i64(raw: &str) -> Result<i64, String> {
+	let value = raw.parse::<i64>().map_err(|_| "limit must be an integer".to_owned())?;
+	if value <= 0 {
+		return Err("limit must be positive".to_owned());
+	}
+	Ok(value)
 }
 
 #[derive(Debug, Args)]
@@ -331,9 +354,9 @@ async fn main() -> Result<()> {
 				let (client, base) = client_and_url(&conn)?;
 				repo_add(&client, base, a).await
 			},
-			RepoCmd::List => {
+			RepoCmd::List(args) => {
 				let (client, base) = client_and_url(&conn)?;
-				repo_list(&client, base).await
+				repo_list(&client, base, args.limit).await
 			},
 			RepoCmd::Rm { id } => {
 				let (client, base) = client_and_url(&conn)?;
@@ -367,9 +390,9 @@ async fn main() -> Result<()> {
 			},
 		},
 		Cmd::Job(c) => match c {
-			JobCmd::List => {
+			JobCmd::List(args) => {
 				let (client, base) = client_and_url(&conn)?;
-				job_list(&client, base).await
+				job_list(&client, base, args.limit).await
 			},
 			JobCmd::Get { id } => {
 				let (client, base) = client_and_url(&conn)?;
@@ -385,9 +408,9 @@ async fn main() -> Result<()> {
 			},
 		},
 		Cmd::Finding(c) => match c {
-			FindingCmd::List { repo_id } => {
+			FindingCmd::List(args) => {
 				let (client, base) = client_and_url(&conn)?;
-				finding_list(&client, base, repo_id).await
+				finding_list(&client, base, args.repo_id, args.limit).await
 			},
 			FindingCmd::Search { repo_id, query, limit } => {
 				let (client, base) = client_and_url(&conn)?;
@@ -534,8 +557,12 @@ async fn repo_add(client: &reqwest::Client, base: &reqwest::Url, a: RepoAddArgs)
 	Ok(())
 }
 
-async fn repo_list(client: &reqwest::Client, base: &reqwest::Url) -> Result<()> {
-	let resp = client.get(url(base, "/v1/repos")).send().await?;
+async fn repo_list(
+	client: &reqwest::Client, base: &reqwest::Url, limit: Option<i64>,
+) -> Result<()> {
+	let req = client.get(url(base, "/v1/repos"));
+	let req = if let Some(limit) = limit { req.query(&[("limit", limit)]) } else { req };
+	let resp = req.send().await?;
 	let body: ListReposResponse = resp.error_for_status()?.json().await?;
 	for r in body.repos {
 		let approval = r.require_approval.map_or("inherit".to_owned(), |v| v.to_string());
@@ -778,8 +805,10 @@ async fn worker_rm(client: &reqwest::Client, base: &reqwest::Url, id: i64) -> Re
 	Ok(())
 }
 
-async fn job_list(client: &reqwest::Client, base: &reqwest::Url) -> Result<()> {
-	let resp = client.get(url(base, "/v1/jobs")).send().await?;
+async fn job_list(client: &reqwest::Client, base: &reqwest::Url, limit: Option<i64>) -> Result<()> {
+	let req = client.get(url(base, "/v1/jobs"));
+	let req = if let Some(limit) = limit { req.query(&[("limit", limit)]) } else { req };
+	let resp = req.send().await?;
 	let jobs: Vec<JobInfo> = resp.error_for_status()?.json().await?;
 	for j in jobs.into_iter().rev() {
 		println!(
@@ -819,8 +848,12 @@ async fn job_cancel(client: &reqwest::Client, base: &reqwest::Url, id: i64) -> R
 	Ok(())
 }
 
-async fn finding_list(client: &reqwest::Client, base: &reqwest::Url, repo_id: i64) -> Result<()> {
-	let resp = client.get(url(base, &format!("/v1/repos/{repo_id}/findings"))).send().await?;
+async fn finding_list(
+	client: &reqwest::Client, base: &reqwest::Url, repo_id: i64, limit: Option<i64>,
+) -> Result<()> {
+	let req = client.get(url(base, &format!("/v1/repos/{repo_id}/findings")));
+	let req = if let Some(limit) = limit { req.query(&[("limit", limit)]) } else { req };
+	let resp = req.send().await?;
 	let body: ListFindingsResponse = resp.error_for_status()?.json().await?;
 	for f in body.findings.into_iter().rev() {
 		let loc = match (f.file_path.as_deref(), f.line_start) {
@@ -1118,6 +1151,72 @@ mod tests {
 			panic!("expected finding retry-report command");
 		};
 		assert_eq!(id, 11);
+	}
+
+	#[test]
+	fn list_limits_parse() {
+		let cli = Cli::try_parse_from([
+			"loupectl",
+			"--server-url",
+			"https://loupe.example:8443",
+			"repo",
+			"list",
+			"-n",
+			"25",
+		])
+		.unwrap();
+		let Cmd::Repo(RepoCmd::List(args)) = cli.cmd else {
+			panic!("expected repo list command");
+		};
+		assert_eq!(args.limit, Some(25));
+
+		let cli = Cli::try_parse_from([
+			"loupectl",
+			"--server-url",
+			"https://loupe.example:8443",
+			"job",
+			"list",
+			"-n",
+			"25",
+		])
+		.unwrap();
+		let Cmd::Job(JobCmd::List(args)) = cli.cmd else {
+			panic!("expected job list command");
+		};
+		assert_eq!(args.limit, Some(25));
+
+		let cli = Cli::try_parse_from([
+			"loupectl",
+			"--server-url",
+			"https://loupe.example:8443",
+			"finding",
+			"list",
+			"7",
+			"-n",
+			"250",
+		])
+		.unwrap();
+		let Cmd::Finding(FindingCmd::List(args)) = cli.cmd else {
+			panic!("expected finding list command");
+		};
+		assert_eq!(args.repo_id, 7);
+		assert_eq!(args.limit, Some(250));
+	}
+
+	#[test]
+	fn list_limits_must_be_positive() {
+		let err = Cli::try_parse_from([
+			"loupectl",
+			"--server-url",
+			"https://loupe.example:8443",
+			"finding",
+			"list",
+			"7",
+			"-n",
+			"0",
+		])
+		.expect_err("zero limit must be rejected");
+		assert!(err.to_string().contains("limit must be positive"));
 	}
 
 	#[test]

--- a/crates/loupe-server/src/routes/findings_admin.rs
+++ b/crates/loupe-server/src/routes/findings_admin.rs
@@ -33,10 +33,8 @@ use serde::Deserialize;
 use crate::auth::AuthedWorker;
 use crate::state::AppState;
 
-/// How many findings the listing endpoint returns by default. Operators
-/// who need to page further should narrow by repo and follow up via
-/// `loupectl finding get <id>` for individual rows.
-const LIST_LIMIT: i64 = 100;
+/// How many findings the listing endpoint returns by default.
+const LIST_DEFAULT_LIMIT: i64 = 100;
 
 /// Default cap on `search` results. The agent typically only needs
 /// the top handful of "is this a duplicate of any prior finding?"
@@ -81,16 +79,31 @@ fn authorize_prior_finding_repo(
 }
 
 pub async fn list_for_repo(
-	State(state): State<AppState>, Path(repo_id): Path<i64>,
+	State(state): State<AppState>, Path(repo_id): Path<i64>, Query(qp): Query<ListQuery>,
 ) -> Result<Json<ListFindingsResponse>, (StatusCode, String)> {
+	let limit = positive_limit(qp.limit)?.unwrap_or(LIST_DEFAULT_LIMIT);
 	let rows = state
 		.db
-		.with_conn(|c| Ok(findings::list_for_repo(c, repo_id, LIST_LIMIT)?))
+		.with_conn(|c| Ok(findings::list_for_repo(c, repo_id, limit)?))
 		.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("listing findings: {e}")))?;
 	Ok(Json(ListFindingsResponse {
 		protocol_version: PROTOCOL_VERSION,
 		findings: rows.into_iter().map(row_to_summary).collect(),
 	}))
+}
+
+/// Query string for `GET /v1/repos/:id/findings`.
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+	#[serde(default)]
+	pub limit: Option<i64>,
+}
+
+fn positive_limit(limit: Option<i64>) -> Result<Option<i64>, (StatusCode, String)> {
+	if matches!(limit, Some(n) if n <= 0) {
+		return Err((StatusCode::BAD_REQUEST, "limit must be positive".into()));
+	}
+	Ok(limit)
 }
 
 /// Query string for `GET /v1/repos/:id/findings/search`.

--- a/crates/loupe-server/src/routes/jobs.rs
+++ b/crates/loupe-server/src/routes/jobs.rs
@@ -18,7 +18,7 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::body::Bytes;
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::{Extension, Json};
 use loupe_core::{FindingState, JobKind, JobState};
@@ -29,6 +29,7 @@ use loupe_proto::{
 };
 use loupe_storage::jobs::{self, JobRow, NewJob, DEFAULT_LEASE_SECONDS};
 use loupe_storage::{findings, repos, secrets};
+use serde::Deserialize;
 
 use crate::auth::AuthedWorker;
 use crate::reporters;
@@ -60,6 +61,19 @@ fn job_to_info(row: &JobRow) -> JobInfo {
 		attempts: row.attempts,
 		enqueued_at: row.enqueued_at,
 	}
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+	#[serde(default)]
+	pub limit: Option<i64>,
+}
+
+fn positive_limit(limit: Option<i64>) -> Result<Option<i64>, (StatusCode, String)> {
+	if matches!(limit, Some(n) if n <= 0) {
+		return Err((StatusCode::BAD_REQUEST, "limit must be positive".into()));
+	}
+	Ok(limit)
 }
 
 /// `POST /v1/repos/:id/scan` — admin enqueues a scan job for `id`.
@@ -100,11 +114,12 @@ pub async fn enqueue_scan(
 
 /// `GET /v1/jobs` — admin lists jobs (most recent first).
 pub async fn list(
-	State(state): State<AppState>,
+	State(state): State<AppState>, Query(qp): Query<ListQuery>,
 ) -> Result<Json<Vec<JobInfo>>, (StatusCode, String)> {
+	let limit = positive_limit(qp.limit)?;
 	let rows = state
 		.db
-		.with_conn(|c| Ok(jobs::list(c)?))
+		.with_conn(|c| Ok(jobs::list(c, limit)?))
 		.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("list jobs: {e}")))?;
 	Ok(Json(rows.iter().map(job_to_info).collect()))
 }

--- a/crates/loupe-server/src/routes/repos.rs
+++ b/crates/loupe-server/src/routes/repos.rs
@@ -2,7 +2,7 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::Json;
 use loupe_core::ReportingDestination;
@@ -12,6 +12,7 @@ use loupe_proto::{
 };
 use loupe_storage::repos::{self, NewRepo, RepoRow, RepoUpdate};
 use loupe_storage::secrets::{self, SecretKind};
+use serde::Deserialize;
 
 use crate::state::AppState;
 
@@ -31,6 +32,19 @@ fn row_to_summary(r: RepoRow) -> RepoSummary {
 		last_scanned_at: r.last_scanned_at,
 		created_at: r.created_at,
 	}
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+	#[serde(default)]
+	pub limit: Option<i64>,
+}
+
+fn positive_limit(limit: Option<i64>) -> Result<Option<i64>, (StatusCode, String)> {
+	if matches!(limit, Some(n) if n <= 0) {
+		return Err((StatusCode::BAD_REQUEST, "limit must be positive".into()));
+	}
+	Ok(limit)
 }
 
 /// `POST /v1/repos` — admin only. Stores the GitHub PAT inline to the
@@ -111,11 +125,12 @@ pub async fn create(
 /// JSON is **not** included: it carries `pat_secret_id` references that
 /// are storage-internal.
 pub async fn list(
-	State(state): State<AppState>,
+	State(state): State<AppState>, Query(qp): Query<ListQuery>,
 ) -> Result<Json<ListReposResponse>, (StatusCode, String)> {
+	let limit = positive_limit(qp.limit)?;
 	let rows = state
 		.db
-		.with_conn(|c| Ok(repos::list(c)?))
+		.with_conn(|c| Ok(repos::list(c, limit)?))
 		.map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("listing repos: {e}")))?;
 	Ok(Json(ListReposResponse {
 		protocol_version: PROTOCOL_VERSION,

--- a/crates/loupe-server/tests/jobs.rs
+++ b/crates/loupe-server/tests/jobs.rs
@@ -203,6 +203,13 @@ async fn submit_finding(worker: &reqwest::Client, job_id: i64, finding: Finding)
 	assert_eq!(resp.status(), 204);
 }
 
+async fn submit_many_findings(worker: &reqwest::Client, job_id: i64, count: usize) {
+	for i in 0..count {
+		submit_finding(worker, job_id, finding(&format!("Finding {i:03}"), &format!("fp-{i:03}")))
+			.await;
+	}
+}
+
 fn finding(title: &str, fingerprint: &str) -> Finding {
 	Finding {
 		scanner_id: "regex".into(),
@@ -217,6 +224,79 @@ fn finding(title: &str, fingerprint: &str) -> Finding {
 		poc_unified: None,
 		fingerprint: fingerprint.into(),
 	}
+}
+
+#[tokio::test]
+async fn list_routes_accept_positive_limits() {
+	let f = bring_up_with_repo_and_worker().await;
+	let repo_b = register_repo(&f, "https://github.com/acme/b.git", "tracker-b").await;
+	let repo_c = register_repo(&f, "https://github.com/acme/c.git", "tracker-c").await;
+
+	let repos = f.admin.get("https://loupe-server/v1/repos?limit=2").send().await.unwrap();
+	assert!(repos.status().is_success());
+	let repos: loupe_proto::ListReposResponse = repos.json().await.unwrap();
+	assert_eq!(repos.repos.len(), 2);
+
+	enqueue_scan(&f, f.repo_id).await;
+	enqueue_scan(&f, repo_b).await;
+	enqueue_scan(&f, repo_c).await;
+
+	let jobs = f.admin.get("https://loupe-server/v1/jobs?limit=2").send().await.unwrap();
+	assert!(jobs.status().is_success());
+	let jobs: Vec<JobInfo> = jobs.json().await.unwrap();
+	assert_eq!(jobs.len(), 2);
+
+	f.handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn list_routes_reject_non_positive_limits() {
+	let f = bring_up_with_repo_and_worker().await;
+	let paths = [
+		"/v1/repos?limit=0".to_owned(),
+		"/v1/jobs?limit=-1".to_owned(),
+		format!("/v1/repos/{}/findings?limit=0", f.repo_id),
+	];
+
+	for path in paths {
+		let resp = f.admin.get(format!("https://loupe-server{path}")).send().await.unwrap();
+		assert_eq!(resp.status(), 400, "{path} should reject non-positive limits");
+		let body = resp.text().await.unwrap();
+		assert!(body.contains("limit must be positive"), "unexpected body for {path}: {body}");
+	}
+
+	f.handle.shutdown().await;
+}
+
+#[tokio::test]
+async fn finding_list_limit_can_exceed_default_page() {
+	let f = bring_up_with_repo_and_worker().await;
+	let scan = enqueue_scan(&f, f.repo_id).await;
+	let env = lease_job(&f.worker).await;
+	assert_eq!(env.job_id, scan.job_id);
+	submit_many_findings(&f.worker, env.job_id, 101).await;
+
+	let default_resp = f
+		.admin
+		.get(format!("https://loupe-server/v1/repos/{}/findings", f.repo_id))
+		.send()
+		.await
+		.unwrap();
+	assert!(default_resp.status().is_success());
+	let default_body: ListFindingsResponse = default_resp.json().await.unwrap();
+	assert_eq!(default_body.findings.len(), 100);
+
+	let resp = f
+		.admin
+		.get(format!("https://loupe-server/v1/repos/{}/findings?limit=101", f.repo_id))
+		.send()
+		.await
+		.unwrap();
+	assert!(resp.status().is_success());
+	let body: ListFindingsResponse = resp.json().await.unwrap();
+	assert_eq!(body.findings.len(), 101);
+
+	f.handle.shutdown().await;
 }
 
 #[tokio::test]

--- a/crates/loupe-storage/src/jobs.rs
+++ b/crates/loupe-storage/src/jobs.rs
@@ -333,13 +333,19 @@ pub fn get(conn: &Connection, id: i64) -> rusqlite::Result<Option<JobRow>> {
 	.optional()
 }
 
-pub fn list(conn: &Connection) -> rusqlite::Result<Vec<JobRow>> {
-	let mut stmt = conn.prepare(&format!(
+pub fn list(conn: &Connection, limit: Option<i64>) -> rusqlite::Result<Vec<JobRow>> {
+	let sql = format!(
 		"SELECT {JOB_COLUMNS}
 		 FROM jobs
 		 ORDER BY enqueued_at DESC, id DESC",
-	))?;
-	let rows = stmt.query_map([], row_to_job)?.collect::<rusqlite::Result<Vec<_>>>()?;
+	);
+	let Some(limit) = limit else {
+		let mut stmt = conn.prepare(&sql)?;
+		let rows = stmt.query_map([], row_to_job)?.collect::<rusqlite::Result<Vec<_>>>()?;
+		return Ok(rows);
+	};
+	let mut stmt = conn.prepare(&format!("{sql} LIMIT ?1"))?;
+	let rows = stmt.query_map(params![limit], row_to_job)?.collect::<rusqlite::Result<Vec<_>>>()?;
 	Ok(rows)
 }
 
@@ -901,7 +907,7 @@ mod tests {
 		db.with_conn(|c| Ok(lease_next(c, worker_id, false, 100, 10)?)).unwrap();
 		let n = db.with_conn(|c| Ok(reap_stale_leases(c, 200)?)).unwrap();
 		assert_eq!(n, 1);
-		let row = db.with_conn(|c| Ok(list(c)?)).unwrap().pop().unwrap();
+		let row = db.with_conn(|c| Ok(list(c, None)?)).unwrap().pop().unwrap();
 		assert_eq!(row.state, JobState::Queued);
 		assert_eq!(row.attempts, 1, "reap doesn't reset attempts");
 	}
@@ -935,7 +941,7 @@ mod tests {
 		// to failed.
 		db.with_conn(|c| Ok(lease_next(c, worker_id, false, 999, 10)?)).unwrap();
 		db.with_conn(|c| Ok(reap_stale_leases(c, 9_999)?)).unwrap();
-		let row = db.with_conn(|c| Ok(list(c)?)).unwrap().pop().unwrap();
+		let row = db.with_conn(|c| Ok(list(c, None)?)).unwrap().pop().unwrap();
 		assert_eq!(row.state, JobState::Failed);
 	}
 
@@ -994,7 +1000,7 @@ mod tests {
 		.unwrap();
 
 		db.with_conn(|c| Ok(reap_stale_leases(c, 9_999)?)).unwrap();
-		let row = db.with_conn(|c| Ok(list(c)?)).unwrap().pop().unwrap();
+		let row = db.with_conn(|c| Ok(list(c, None)?)).unwrap().pop().unwrap();
 		assert_eq!(row.state, JobState::Failed);
 		let pending_findings: i64 = db
 			.with_conn(|c| {

--- a/crates/loupe-storage/src/repos.rs
+++ b/crates/loupe-storage/src/repos.rs
@@ -73,9 +73,15 @@ pub fn insert(conn: &Connection, new: &NewRepo, now: i64) -> rusqlite::Result<i6
 	Ok(conn.last_insert_rowid())
 }
 
-pub fn list(conn: &Connection) -> rusqlite::Result<Vec<RepoRow>> {
-	let mut stmt = conn.prepare(SELECT_REPO_COLUMNS)?;
-	let rows = stmt.query_map([], row_to_repo)?.collect::<rusqlite::Result<Vec<_>>>()?;
+pub fn list(conn: &Connection, limit: Option<i64>) -> rusqlite::Result<Vec<RepoRow>> {
+	let Some(limit) = limit else {
+		let mut stmt = conn.prepare(SELECT_REPO_COLUMNS)?;
+		let rows = stmt.query_map([], row_to_repo)?.collect::<rusqlite::Result<Vec<_>>>()?;
+		return Ok(rows);
+	};
+	let mut stmt = conn.prepare(&format!("{SELECT_REPO_COLUMNS} LIMIT ?1"))?;
+	let rows =
+		stmt.query_map(params![limit], row_to_repo)?.collect::<rusqlite::Result<Vec<_>>>()?;
 	Ok(rows)
 }
 
@@ -260,7 +266,7 @@ mod tests {
 			.unwrap();
 		let id = db.with_conn(|c| Ok(insert(c, &fake_repo(secret_id), 100)?)).unwrap();
 
-		let listed = db.with_conn(|c| Ok(list(c)?)).unwrap();
+		let listed = db.with_conn(|c| Ok(list(c, None)?)).unwrap();
 		assert_eq!(listed.len(), 1);
 		assert_eq!(listed[0].id, id);
 		assert_eq!(listed[0].clone_url, "https://github.com/acme/widget.git");
@@ -277,7 +283,7 @@ mod tests {
 		}
 
 		assert!(db.with_conn(|c| Ok(delete(c, id)?)).unwrap());
-		assert!(db.with_conn(|c| Ok(list(c)?)).unwrap().is_empty());
+		assert!(db.with_conn(|c| Ok(list(c, None)?)).unwrap().is_empty());
 	}
 
 	#[test]


### PR DESCRIPTION
Add positive row limits to list commands so older findings, jobs, and repos can be retrieved before pagination exists.

Co-Authored-By: HAL 9000