### PR TITLE
Make loupe work on NixOS

### DIFF
--- a/crates/loupe-worker/src/sandbox.rs
+++ b/crates/loupe-worker/src/sandbox.rs
@@ -202,8 +202,9 @@ impl SandboxBuilder {
 
 		// Read-only system directories. /lib and /lib64 are platform-
 		// dependent: glibc systems have /lib64, musl typically does not.
-		// We bind whichever exists.
-		for ro in ["/usr", "/etc", "/lib", "/lib64", "/bin", "/sbin"] {
+		// /nix/store covers Nix-based hosts, where the FHS dirs are just
+		// symlink farms into it. We bind whichever of these exists.
+		for ro in ["/usr", "/etc", "/lib", "/lib64", "/bin", "/sbin", "/nix/store"] {
 			if Path::new(ro).exists() {
 				cmd.args(["--ro-bind-try", ro, ro]);
 			}

--- a/crates/loupe-worker/src/sandbox.rs
+++ b/crates/loupe-worker/src/sandbox.rs
@@ -390,8 +390,10 @@ fn locate_on_path(name: &str) -> Option<PathBuf> {
 /// invocation fail; calling this once at startup surfaces that early
 /// rather than mid-job.
 pub fn smoketest(workdir: &Path) -> Result<()> {
-	let builder = SandboxBuilder::new(workdir);
-	let mut cmd = builder.build("/bin/true");
+	// Resolve `true` on PATH rather than hardcoding `/bin/true`, which
+	// is absent on non-FHS hosts.
+	let builder = SandboxBuilder::new(workdir).allow_binary("true")?;
+	let mut cmd = builder.build("true");
 	cmd.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::piped());
 	let output = std::process::Command::new(cmd.as_std().get_program())
 		.args(cmd.as_std().get_args())


### PR DESCRIPTION
Two fixes to `loupe-worker`'s bwrap sandbox, each of which blocks the
LLM scanner on a NixOS host (and, for the first, any distro that ships
coreutils outside the FHS layout). Split out from an unrelated proxy fix
so this PR is purely about the Nix / non-FHS layout.

### Fix bwrap smoketest on non-FHS hosts
The startup smoketest hardcoded `/bin/true`, which does not exist on
NixOS (and other distros that ship coreutils outside `/bin`), so the
worker hard-failed at startup even where bwrap works fully — forcing
operators onto `LOUPE_DISABLE_SANDBOX`, which in turn breaks MCP (the
`/loupe/*` bind targets only exist inside the sandbox namespace).
Invoke `true` by name via `allow_binary` + `build("true")`, mounting
whichever `true` is on PATH — mirroring how the real scanner binaries
(claude/codex) are made reachable.

### Bind /nix/store into the sandbox
On NixOS (and any Linux host with a Nix install) every binary's ELF
interpreter and shared libraries live under `/nix/store`; the FHS dirs
the sandbox binds are near-empty symlink farms into the store. Without
`/nix/store` bound, no dynamically linked binary can `exec` inside the
namespace — bwrap fails with `execvp: No such file or directory`. Add
it to the `--ro-bind-try` set, so it stays a no-op on FHS hosts.

### Testing
Ran the fixed worker against a live server on NixOS: the startup
smoketest passes and the LLM scanner leases and completes a scan to
submission instead of being reaped as a stale lease.
