### PR TITLE
Bind /nix into the sandbox when present

### DIFF
--- a/crates/loupe-worker/src/sandbox.rs
+++ b/crates/loupe-worker/src/sandbox.rs
@@ -203,7 +203,7 @@ impl SandboxBuilder {
 		// Read-only system directories. /lib and /lib64 are platform-
 		// dependent: glibc systems have /lib64, musl typically does not.
 		// We bind whichever exists.
-		for ro in ["/usr", "/etc", "/lib", "/lib64", "/bin", "/sbin"] {
+		for ro in ["/usr", "/etc", "/lib", "/lib64", "/bin", "/sbin", "/nix"] {
 			if Path::new(ro).exists() {
 				cmd.args(["--ro-bind-try", ro, ro]);
 			}


### PR DESCRIPTION
On NixOS, binaries live in /nix/store and the FHS paths the sandbox mounts are symlinks into it, so /bin/sh and anything else resolved inside bwrap failed with "execvp: No such file or directory". Binding /nix read-only fixes that. Hosts without /nix skip the entry, same as /lib64 on musl.