### PR TITLE
Private-repo clone tokens, per-role model overrides, rate-limit backoff, usage accounting

### DIFF
--- a/crates/loupe-cli/src/main.rs
+++ b/crates/loupe-cli/src/main.rs
@@ -540,6 +540,7 @@ async fn repo_add(client: &reqwest::Client, base: &reqwest::Url, a: RepoAddArgs)
 	let req = RegisterRepoRequest {
 		protocol_version: PROTOCOL_VERSION,
 		clone_url: a.clone_url,
+		clone_token: std::env::var("LOUPE_CLONE_TOKEN").ok(),
 		branch: a.branch,
 		scan_interval_seconds: a.scan_interval_seconds,
 		reporting,

--- a/crates/loupe-proto/src/lease.rs
+++ b/crates/loupe-proto/src/lease.rs
@@ -51,6 +51,10 @@ pub struct LeaseEnvelope {
 	pub scanner_config: serde_json::Value,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub github_pat: Option<String>,
+	/// Clone credential for private repos (stored separately from the
+	/// reporting PAT). The worker prefers this over `github_pat`.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub clone_token: Option<String>,
 	pub payload: LeasePayload,
 }
 
@@ -107,6 +111,7 @@ mod tests {
 			lease_expires_at: 1_700_000_600,
 			scanner_config: json!({"regex": {"enabled": true}}),
 			github_pat: None,
+			clone_token: None,
 			payload: LeasePayload::Scan { since_sha: Some("abc123".into()) },
 		};
 		let r = LeaseResponse::Lease(Box::new(env.clone()));
@@ -139,6 +144,7 @@ mod tests {
 			lease_expires_at: 1_700_000_800,
 			scanner_config: serde_json::Value::Null,
 			github_pat: None,
+			clone_token: None,
 			payload: LeasePayload::Verify {
 				finding_id: 42,
 				finding: Box::new(finding.clone()),

--- a/crates/loupe-proto/src/registry.rs
+++ b/crates/loupe-proto/src/registry.rs
@@ -37,6 +37,11 @@ pub enum ReportingSetup {
 pub struct RegisterRepoRequest {
 	pub protocol_version: u16,
 	pub clone_url: String,
+	/// Optional bearer token / PAT for cloning a PRIVATE repository. Stored
+	/// encrypted in the `secrets` table (never in `clone_url`), so it never
+	/// appears in `repo list`.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub clone_token: Option<String>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub branch: Option<String>,
 	#[serde(default, skip_serializing_if = "Option::is_none")]
@@ -63,6 +68,7 @@ impl RegisterRepoRequest {
 		Self {
 			protocol_version: PROTOCOL_VERSION,
 			clone_url: clone_url.into(),
+			clone_token: None,
 			branch: None,
 			scan_interval_seconds: None,
 			reporting,
@@ -183,6 +189,7 @@ mod tests {
 		let req = RegisterRepoRequest {
 			protocol_version: PROTOCOL_VERSION,
 			clone_url: "https://github.com/acme/widget.git".into(),
+			clone_token: None,
 			branch: Some("main".into()),
 			scan_interval_seconds: Some(3600),
 			reporting: ReportingSetup::GithubIssue {

--- a/crates/loupe-server/src/background.rs
+++ b/crates/loupe-server/src/background.rs
@@ -159,6 +159,7 @@ mod tests {
 						},
 						verification_enabled: false,
 						require_approval: None,
+						clone_token_secret_id: None,
 					},
 					0,
 				)?)

--- a/crates/loupe-server/src/reporters/email.rs
+++ b/crates/loupe-server/src/reporters/email.rs
@@ -171,6 +171,7 @@ mod tests {
 			reporting: ReportingDestination::Email { to, from, subject_prefix },
 			verification_enabled: false,
 			require_approval: None,
+			clone_token_secret_id: None,
 			last_scanned_sha: None,
 			last_scanned_at: None,
 			created_at: 0,

--- a/crates/loupe-server/src/reporters/github.rs
+++ b/crates/loupe-server/src/reporters/github.rs
@@ -285,6 +285,7 @@ mod tests {
 			},
 			verification_enabled: false,
 			require_approval: None,
+			clone_token_secret_id: None,
 			last_scanned_sha: None,
 			last_scanned_at: None,
 			created_at: 0,

--- a/crates/loupe-server/src/routes/jobs.rs
+++ b/crates/loupe-server/src/routes/jobs.rs
@@ -272,9 +272,16 @@ fn build_lease_envelope(state: &AppState, row: &JobRow) -> anyhow::Result<LeaseE
 		.db
 		.with_conn(|c| Ok(repos::get(c, row.repo_id)?))?
 		.ok_or_else(|| anyhow::anyhow!("repo {} for leased job not found", row.repo_id))?;
-	// No clone-side credential is stored separately. We deliberately do
-	// not ship the reporting PAT to the worker.
+	// Decrypt the per-repo clone token (private repos) for the worker.
+	// We still do not ship the reporting PAT.
 	let github_pat: Option<String> = None;
+	let clone_token: Option<String> = match repo.clone_token_secret_id {
+		Some(sid) => state
+			.db
+			.with_conn(|c| Ok(loupe_storage::secrets::read(c, sid)?))?
+			.and_then(|bytes| String::from_utf8(bytes).ok()),
+		None => None,
+	};
 
 	let payload = match row.kind {
 		JobKind::Scan => LeasePayload::Scan { since_sha: row.since_sha.clone() },
@@ -319,6 +326,7 @@ fn build_lease_envelope(state: &AppState, row: &JobRow) -> anyhow::Result<LeaseE
 		lease_expires_at: row.lease_expires_at.unwrap_or(0),
 		scanner_config: repo.scanner_config,
 		github_pat,
+		clone_token,
 		payload,
 	})
 }

--- a/crates/loupe-server/src/routes/repos.rs
+++ b/crates/loupe-server/src/routes/repos.rs
@@ -92,6 +92,13 @@ pub async fn create(
 				},
 				ReportingSetup::Manual => ReportingDestination::Manual,
 			};
+			let clone_token_secret_id = match &req.clone_token {
+				Some(tok) => {
+					let label = format!("clone-token:{}:{}/{}", parsed.0, parsed.1, parsed.2);
+					Some(secrets::insert(&tx, SecretKind::CloneToken, &label, tok.as_bytes(), now)?)
+				},
+				None => None,
+			};
 			let id = repos::insert(
 				&tx,
 				&NewRepo {
@@ -107,6 +114,7 @@ pub async fn create(
 						.verification_enabled
 						.unwrap_or(state.verification_default),
 					require_approval: req.require_approval,
+					clone_token_secret_id,
 				},
 				now,
 			)?;

--- a/crates/loupe-server/tests/approval_flow.rs
+++ b/crates/loupe-server/tests/approval_flow.rs
@@ -185,6 +185,7 @@ async fn register_with(
 			// We patch this to the local file:// path after registration so
 			// the URL parser still sees a github.com host on the way in.
 			clone_url: format!("https://github.com/loupe/{target_repo}.git"),
+			clone_token: None,
 			branch: None,
 			scan_interval_seconds: None,
 			reporting,

--- a/crates/loupe-server/tests/dispatch.rs
+++ b/crates/loupe-server/tests/dispatch.rs
@@ -158,6 +158,7 @@ async fn dispatcher_opens_a_github_issue_after_a_succeeded_scan() {
 		.json(&RegisterRepoRequest {
 			protocol_version: PROTOCOL_VERSION,
 			clone_url: "https://github.com/loupe/test-target.git".into(),
+			clone_token: None,
 			branch: None,
 			scan_interval_seconds: None,
 			reporting: ReportingSetup::GithubIssue {
@@ -321,6 +322,7 @@ async fn dispatch_only_marks_confirmed_findings_reported() {
 		.json(&RegisterRepoRequest {
 			protocol_version: PROTOCOL_VERSION,
 			clone_url: "https://github.com/loupe/test-target.git".into(),
+			clone_token: None,
 			branch: None,
 			scan_interval_seconds: None,
 			reporting: ReportingSetup::GithubIssue {

--- a/crates/loupe-server/tests/email_dispatch.rs
+++ b/crates/loupe-server/tests/email_dispatch.rs
@@ -102,6 +102,7 @@ async fn email_reporter_invokes_sendmail_with_findings() {
 		.json(&RegisterRepoRequest {
 			protocol_version: PROTOCOL_VERSION,
 			clone_url: "https://github.com/loupe/test-target.git".into(),
+			clone_token: None,
 			branch: None,
 			scan_interval_seconds: None,
 			reporting: ReportingSetup::Email {

--- a/crates/loupe-server/tests/jobs.rs
+++ b/crates/loupe-server/tests/jobs.rs
@@ -81,6 +81,7 @@ async fn bring_up_with_repo_and_worker() -> Fixture {
 	let req = RegisterRepoRequest {
 		protocol_version: PROTOCOL_VERSION,
 		clone_url: "https://github.com/acme/widget.git".into(),
+		clone_token: None,
 		branch: Some("main".into()),
 		scan_interval_seconds: None,
 		reporting: ReportingSetup::GithubIssue {
@@ -115,6 +116,7 @@ async fn register_repo(f: &Fixture, clone_url: &str, target_repo: &str) -> i64 {
 	let req = RegisterRepoRequest {
 		protocol_version: PROTOCOL_VERSION,
 		clone_url: clone_url.into(),
+		clone_token: None,
 		branch: Some("main".into()),
 		scan_interval_seconds: None,
 		reporting: ReportingSetup::GithubIssue {

--- a/crates/loupe-server/tests/llm_dispatch.rs
+++ b/crates/loupe-server/tests/llm_dispatch.rs
@@ -149,6 +149,7 @@ async fn llm_scanner_full_pipeline_dispatches_via_github() {
 		.json(&RegisterRepoRequest {
 			protocol_version: PROTOCOL_VERSION,
 			clone_url: "https://github.com/loupe/test-target.git".into(),
+			clone_token: None,
 			branch: None,
 			scan_interval_seconds: None,
 			reporting: ReportingSetup::GithubIssue {

--- a/crates/loupe-server/tests/repos.rs
+++ b/crates/loupe-server/tests/repos.rs
@@ -87,6 +87,7 @@ async fn create_repo(admin: &reqwest::Client, reporting: ReportingSetup) -> i64 
 	let req = RegisterRepoRequest {
 		protocol_version: PROTOCOL_VERSION,
 		clone_url: "https://github.com/acme/widget.git".into(),
+		clone_token: None,
 		branch: Some("main".into()),
 		scan_interval_seconds: Some(3600),
 		reporting,
@@ -128,6 +129,7 @@ async fn admin_can_register_list_and_delete_a_repo() {
 	let req = RegisterRepoRequest {
 		protocol_version: PROTOCOL_VERSION,
 		clone_url: "https://github.com/acme/widget.git".into(),
+		clone_token: None,
 		branch: Some("main".into()),
 		scan_interval_seconds: Some(3600),
 		reporting: ReportingSetup::GithubIssue {
@@ -206,6 +208,7 @@ async fn repo_registration_inherits_verification_default_unless_pinned() {
 	let inherited = RegisterRepoRequest {
 		protocol_version: PROTOCOL_VERSION,
 		clone_url: "https://github.com/acme/inherit.git".into(),
+		clone_token: None,
 		branch: None,
 		scan_interval_seconds: None,
 		reporting: ReportingSetup::Manual,
@@ -219,6 +222,7 @@ async fn repo_registration_inherits_verification_default_unless_pinned() {
 	let pinned = RegisterRepoRequest {
 		protocol_version: PROTOCOL_VERSION,
 		clone_url: "https://github.com/acme/pinned.git".into(),
+		clone_token: None,
 		branch: None,
 		scan_interval_seconds: None,
 		reporting: ReportingSetup::Manual,
@@ -383,6 +387,7 @@ async fn registering_with_non_https_clone_url_400s() {
 		let req = RegisterRepoRequest {
 			protocol_version: PROTOCOL_VERSION,
 			clone_url: clone_url.into(),
+			clone_token: None,
 			branch: None,
 			scan_interval_seconds: None,
 			reporting: ReportingSetup::GithubIssue {

--- a/crates/loupe-server/tests/verify_flow.rs
+++ b/crates/loupe-server/tests/verify_flow.rs
@@ -184,6 +184,7 @@ async fn run_flow(
 		.json(&RegisterRepoRequest {
 			protocol_version: PROTOCOL_VERSION,
 			clone_url: "https://github.com/loupe/test-target.git".into(),
+			clone_token: None,
 			branch: None,
 			scan_interval_seconds: None,
 			reporting: ReportingSetup::GithubIssue {

--- a/crates/loupe-storage/src/findings.rs
+++ b/crates/loupe-storage/src/findings.rs
@@ -565,6 +565,7 @@ mod tests {
 						},
 						verification_enabled: false,
 						require_approval: None,
+						clone_token_secret_id: None,
 					},
 					0,
 				)?)
@@ -770,6 +771,7 @@ mod tests {
 						},
 						verification_enabled: false,
 						require_approval: None,
+						clone_token_secret_id: None,
 					},
 					0,
 				)?)

--- a/crates/loupe-storage/src/jobs.rs
+++ b/crates/loupe-storage/src/jobs.rs
@@ -496,6 +496,7 @@ mod tests {
 						},
 						verification_enabled: false,
 						require_approval: None,
+						clone_token_secret_id: None,
 					},
 					0,
 				)?)

--- a/crates/loupe-storage/src/migrations.rs
+++ b/crates/loupe-storage/src/migrations.rs
@@ -16,7 +16,14 @@ struct Migration {
 }
 
 /// The full migration list. New migrations are appended here.
-const MIGRATIONS: &[Migration] = &[Migration { version: 1, sql: V1_INITIAL }];
+const MIGRATIONS: &[Migration] =
+	&[Migration { version: 1, sql: V1_INITIAL }, Migration { version: 2, sql: V2_CLONE_TOKEN }];
+
+/// v2: add `clone_token_secret_id` so private-repo clone credentials can
+/// be stored separately from the clone URL (and thus kept out of `repo
+/// list` output). Nullable — existing rows get NULL (no clone token).
+const V2_CLONE_TOKEN: &str =
+	"ALTER TABLE registered_repos ADD COLUMN clone_token_secret_id INTEGER;";
 
 /// The highest version this build knows about.
 pub const LATEST_SCHEMA_VERSION: u32 = {

--- a/crates/loupe-storage/src/repos.rs
+++ b/crates/loupe-storage/src/repos.rs
@@ -24,6 +24,9 @@ pub struct RepoRow {
 	pub last_scanned_at: Option<i64>,
 	pub created_at: i64,
 	pub disabled_at: Option<i64>,
+	/// FK into `secrets` for a private-repo clone token. `None` for public
+	/// repos (or repos whose clone URL carries creds inline — discouraged).
+	pub clone_token_secret_id: Option<i64>,
 }
 
 impl RepoRow {
@@ -48,14 +51,16 @@ pub struct NewRepo {
 	/// `None` lets the server default decide; `Some(_)` pins the per-repo
 	/// override on insert.
 	pub require_approval: Option<bool>,
+	pub clone_token_secret_id: Option<i64>,
 }
 
 pub fn insert(conn: &Connection, new: &NewRepo, now: i64) -> rusqlite::Result<i64> {
 	conn.execute(
 		"INSERT INTO registered_repos
 		   (clone_url, host, owner, repo, default_branch, scan_interval_seconds,
-		    scanner_config, reporting, verification_enabled, require_approval, created_at)
-		 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+		    scanner_config, reporting, verification_enabled, require_approval, created_at,
+		    clone_token_secret_id)
+		 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
 		params![
 			new.clone_url,
 			new.host,
@@ -68,6 +73,7 @@ pub fn insert(conn: &Connection, new: &NewRepo, now: i64) -> rusqlite::Result<i6
 			new.verification_enabled as i64,
 			new.require_approval.map(|b| b as i64),
 			now,
+			new.clone_token_secret_id,
 		],
 	)?;
 	Ok(conn.last_insert_rowid())
@@ -200,7 +206,8 @@ pub fn list_due_for_scan(conn: &Connection, now: i64) -> rusqlite::Result<Vec<Re
 const SELECT_REPO_COLUMNS: &str = r#"
 SELECT id, clone_url, host, owner, repo, default_branch, scan_interval_seconds,
        scanner_config, reporting, verification_enabled, require_approval,
-       last_scanned_sha, last_scanned_at, created_at, disabled_at
+       last_scanned_sha, last_scanned_at, created_at, disabled_at,
+       clone_token_secret_id
 FROM registered_repos
 "#;
 
@@ -228,6 +235,7 @@ fn row_to_repo(row: &rusqlite::Row) -> rusqlite::Result<RepoRow> {
 		last_scanned_at: row.get(12)?,
 		created_at: row.get(13)?,
 		disabled_at: row.get(14)?,
+		clone_token_secret_id: row.get(15)?,
 	})
 }
 
@@ -255,6 +263,7 @@ mod tests {
 			},
 			verification_enabled: false,
 			require_approval: None,
+			clone_token_secret_id: None,
 		}
 	}
 
@@ -324,6 +333,7 @@ mod tests {
 			},
 			verification_enabled: false,
 			require_approval: None,
+			clone_token_secret_id: None,
 		};
 		// Repo B: scanned at t=1000, interval=60. Due at t=1060.
 		let b = NewRepo {

--- a/crates/loupe-storage/src/secrets.rs
+++ b/crates/loupe-storage/src/secrets.rs
@@ -75,12 +75,14 @@ impl std::fmt::Debug for MasterKey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SecretKind {
 	GithubPat,
+	CloneToken,
 }
 
 impl SecretKind {
 	pub fn as_str(self) -> &'static str {
 		match self {
 			SecretKind::GithubPat => "github_pat",
+			SecretKind::CloneToken => "clone_token",
 		}
 	}
 }

--- a/crates/loupe-worker/src/config.rs
+++ b/crates/loupe-worker/src/config.rs
@@ -61,6 +61,8 @@ pub struct AgentsConfig {
 	pub verify: JobAgent,
 	pub claude: CliModelConfig,
 	pub codex: CliModelConfig,
+	pub scan_model: Option<CliModelConfig>,
+	pub verify_model: Option<CliModelConfig>,
 }
 
 #[derive(Debug, Clone)]
@@ -172,6 +174,13 @@ pub struct AgentsSection {
 	pub claude: AgentSection,
 	#[serde(default)]
 	pub codex: AgentSection,
+	/// Optional model/effort/provider override applied to the SCAN role,
+	/// regardless of which backend (codex/claude) the role selects.
+	#[serde(default)]
+	pub scan_model: Option<AgentSection>,
+	/// Optional model/effort/provider override applied to the VERIFY role.
+	#[serde(default)]
+	pub verify_model: Option<AgentSection>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -181,6 +190,10 @@ pub struct AgentSection {
 	pub model: Option<String>,
 	#[serde(default)]
 	pub effort: Option<String>,
+	#[serde(default)]
+	pub provider: Option<String>,
+	#[serde(default)]
+	pub api_key_env: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -265,6 +278,28 @@ impl WorkerConfig {
 		}
 		if let Some(v) = file.agents.codex.effort {
 			self.agents.codex.effort = v;
+		}
+		if let Some(v) = file.agents.claude.provider {
+			self.agents.claude.provider = Some(v);
+		}
+		if let Some(v) = file.agents.codex.provider {
+			self.agents.codex.provider = Some(v);
+		}
+		if let Some(section) = file.agents.scan_model {
+			self.agents.scan_model = Some(CliModelConfig {
+				model: section.model.unwrap_or_else(|| self.agents.codex.model.clone()),
+				effort: section.effort.unwrap_or_else(|| self.agents.codex.effort.clone()),
+				provider: section.provider,
+				api_key_env: section.api_key_env,
+			});
+		}
+		if let Some(section) = file.agents.verify_model {
+			self.agents.verify_model = Some(CliModelConfig {
+				model: section.model.unwrap_or_else(|| self.agents.codex.model.clone()),
+				effort: section.effort.unwrap_or_else(|| self.agents.codex.effort.clone()),
+				provider: section.provider,
+				api_key_env: section.api_key_env,
+			});
 		}
 		if let Some(v) = file.scanner_defaults.max_concurrent_files {
 			self.scanner_defaults.max_concurrent_files = v;
@@ -360,6 +395,22 @@ impl WorkerConfig {
 			&self.agents.codex.effort,
 			&["none", "low", "medium", "high", "xhigh"],
 		)?;
+		if let Some(m) = &self.agents.scan_model {
+			validate_nonempty("agents.scan_model.model", &m.model)?;
+			validate_effort(
+				"agents.scan_model.effort",
+				&m.effort,
+				&["none", "low", "medium", "high", "xhigh", "max"],
+			)?;
+		}
+		if let Some(m) = &self.agents.verify_model {
+			validate_nonempty("agents.verify_model.model", &m.model)?;
+			validate_effort(
+				"agents.verify_model.effort",
+				&m.effort,
+				&["none", "low", "medium", "high", "xhigh", "max"],
+			)?;
+		}
 		validate_effort(
 			"logging.level",
 			&self.logging.level,
@@ -406,11 +457,17 @@ impl Default for WorkerConfig {
 				claude: CliModelConfig {
 					model: DEFAULT_CLAUDE_MODEL.to_owned(),
 					effort: DEFAULT_CLAUDE_EFFORT.to_owned(),
+					provider: None,
+					api_key_env: None,
 				},
 				codex: CliModelConfig {
 					model: DEFAULT_CODEX_MODEL.to_owned(),
 					effort: DEFAULT_CODEX_EFFORT.to_owned(),
+					provider: None,
+					api_key_env: None,
 				},
+				scan_model: None,
+				verify_model: None,
 			},
 			scanner_defaults: LlmScannerConfig {
 				max_concurrent_files: DEFAULT_MAX_CONCURRENT_FILES,
@@ -491,6 +548,44 @@ mod tests {
 		assert_eq!(cfg.agents.codex.effort, "xhigh");
 		assert_eq!(cfg.scanner_defaults.max_file_bytes, 2 * 1024 * 1024);
 		assert_eq!(cfg.bkb.api_url, "https://bitcoinknowledge.dev");
+	}
+
+	#[test]
+	fn verify_model_override_replaces_codex_config_for_verify_role() {
+		let dir = tempfile::tempdir().unwrap();
+		let path = dir.path().join("verify.toml");
+		std::fs::write(
+			&path,
+			r#"
+[agents]
+scan = "codex"
+verify = "codex"
+
+[agents.codex]
+model = "glm-5.2"
+effort = "high"
+provider = "zai"
+
+[agents.verify_model]
+model = "kimi-k3"
+effort = "high"
+provider = "moonshot"
+api_key_env = "MOONSHOT_API_KEY"
+"#,
+		)
+		.unwrap();
+		let cfg = WorkerConfig::load(Some(&path), WorkerConfigOverrides::default()).unwrap();
+		// scan role keeps the codex default (GLM / Z.AI), no per-role key env.
+		assert_eq!(cfg.agents.codex.model, "glm-5.2");
+		assert_eq!(cfg.agents.codex.provider.as_deref(), Some("zai"));
+		assert!(cfg.agents.codex.api_key_env.is_none());
+		// verify role is overridden to Kimi / Moonshot with its own key env.
+		let v = cfg.agents.verify_model.expect("verify_model override set");
+		assert_eq!(v.model, "kimi-k3");
+		assert_eq!(v.provider.as_deref(), Some("moonshot"));
+		assert_eq!(v.api_key_env.as_deref(), Some("MOONSHOT_API_KEY"));
+		// scan_model stays unset when only verify_model is configured.
+		assert!(cfg.agents.scan_model.is_none());
 	}
 
 	#[test]

--- a/crates/loupe-worker/src/llm/claude_cli.rs
+++ b/crates/loupe-worker/src/llm/claude_cli.rs
@@ -29,6 +29,7 @@ use tokio::time::timeout;
 use super::mcp::{
 	bind_mcp_into_sandbox, mcp_serve_args, McpContext, SANDBOX_BKB_MCP_BIN, SANDBOX_LOUPE_BIN,
 };
+use super::usage::{now_ms, UsageEvent, UsageRecorder};
 use super::{summarize_cli_stream_for_error, CliModelConfig, LlmBackend, LlmRequest, LlmResponse};
 use crate::sandbox::SandboxBuilder;
 
@@ -116,6 +117,7 @@ pub struct ClaudeCliBackend {
 	agent: CliModelConfig,
 	mcp: Option<McpContext>,
 	log_agent_output: bool,
+	usage: Option<std::sync::Arc<UsageRecorder>>,
 	#[cfg(test)]
 	disable_sandbox: bool,
 }
@@ -132,9 +134,15 @@ impl ClaudeCliBackend {
 			},
 			mcp: None,
 			log_agent_output: false,
+			usage: None,
 			#[cfg(test)]
 			disable_sandbox: false,
 		}
+	}
+
+	pub fn with_usage_recorder(mut self, usage: std::sync::Arc<UsageRecorder>) -> Self {
+		self.usage = Some(usage);
+		self
 	}
 
 	pub fn with_bin(bin: impl Into<String>) -> Self {
@@ -364,7 +372,25 @@ impl LlmBackend for ClaudeCliBackend {
 			stderr_chars = stderr.len(),
 			"claude-cli: subprocess succeeded",
 		);
-		Ok(LlmResponse { text, backend_id: BACKEND_ID })
+		if let Some(rec) = &self.usage {
+			// Claude text mode doesn't expose token counts yet; still record
+			// the session so funding spreadsheets see call volume.
+			rec.record(UsageEvent {
+				ts_unix_ms: now_ms(),
+				backend: BACKEND_ID.to_owned(),
+				model: self.agent.model.clone(),
+				provider: self.agent.provider.clone(),
+				repo_id: req.repo_id,
+				job_id: req.job_id,
+				finding_id: req.finding_id,
+				file: req.usage_label.clone(),
+				ok: true,
+				elapsed_ms: started.elapsed().as_millis() as u64,
+				usage: Default::default(),
+				estimated_usd: None,
+			});
+		}
+		Ok(LlmResponse { text, backend_id: BACKEND_ID, usage: None })
 	}
 }
 
@@ -485,6 +511,7 @@ mod tests {
 			repo_id: None,
 			job_id: None,
 			finding_id: None,
+			usage_label: None,
 		};
 		let resp = backend.run(req).await.expect("claude responded");
 		assert_eq!(resp.backend_id, BACKEND_ID);
@@ -504,6 +531,7 @@ mod tests {
 			repo_id: None,
 			job_id: None,
 			finding_id: None,
+			usage_label: None,
 		};
 		let err = backend.run(req).await.expect_err("must error");
 		let msg = err.to_string().to_lowercase();
@@ -540,6 +568,7 @@ mod tests {
 			repo_id: None,
 			job_id: None,
 			finding_id: None,
+			usage_label: None,
 		};
 
 		let err = backend.run(req).await.expect_err("must time out");

--- a/crates/loupe-worker/src/llm/claude_cli.rs
+++ b/crates/loupe-worker/src/llm/claude_cli.rs
@@ -127,6 +127,8 @@ impl ClaudeCliBackend {
 			agent: CliModelConfig {
 				model: DEFAULT_CLAUDE_MODEL.to_owned(),
 				effort: DEFAULT_CLAUDE_EFFORT.to_owned(),
+				provider: None,
+				api_key_env: None,
 			},
 			mcp: None,
 			log_agent_output: false,
@@ -560,7 +562,12 @@ mod tests {
 	#[test]
 	fn invocation_args_include_configured_model_and_effort() {
 		let args = claude_invocation_args(
-			&CliModelConfig { model: "claude-test".into(), effort: "xhigh".into() },
+			&CliModelConfig {
+				model: "claude-test".into(),
+				effort: "xhigh".into(),
+				provider: None,
+				api_key_env: None,
+			},
 			"hello",
 		);
 

--- a/crates/loupe-worker/src/llm/codex_cli.rs
+++ b/crates/loupe-worker/src/llm/codex_cli.rs
@@ -31,6 +31,7 @@ use tokio::time::timeout;
 use super::mcp::{
 	bind_mcp_into_sandbox, mcp_serve_args, McpContext, SANDBOX_BKB_MCP_BIN, SANDBOX_LOUPE_BIN,
 };
+use super::usage::{now_ms, parse_codex_jsonl, UsageEvent, UsageRecorder};
 use super::{
 	codex_api_key_env, codex_home_dir, summarize_cli_stream_for_error, CliModelConfig, LlmBackend,
 	LlmRequest, LlmResponse,
@@ -81,6 +82,7 @@ pub struct CodexCliBackend {
 	agent: CliModelConfig,
 	mcp: Option<McpContext>,
 	log_agent_output: bool,
+	usage: Option<std::sync::Arc<UsageRecorder>>,
 	#[cfg(test)]
 	disable_sandbox: bool,
 }
@@ -97,9 +99,15 @@ impl CodexCliBackend {
 			},
 			mcp: None,
 			log_agent_output: false,
+			usage: None,
 			#[cfg(test)]
 			disable_sandbox: false,
 		}
+	}
+
+	pub fn with_usage_recorder(mut self, usage: std::sync::Arc<UsageRecorder>) -> Self {
+		self.usage = Some(usage);
+		self
 	}
 
 	pub fn with_bin(bin: impl Into<String>) -> Self {
@@ -306,30 +314,68 @@ impl LlmBackend for CodexCliBackend {
 		if !status.success() {
 			let stderr_text = String::from_utf8_lossy(&stderr);
 			let stdout_text = String::from_utf8_lossy(&stdout);
+			let (_partial_text, partial_usage) = parse_codex_jsonl(&stdout_text);
 			tracing::debug!(
 				backend = BACKEND_ID,
 				exit = ?status.code(),
 				stdout_chars = stdout.len(),
 				stderr_chars = stderr.len(),
 				elapsed_ms = started.elapsed().as_millis() as u64,
+				partial_total_tokens = partial_usage.as_ref().map(|u| u.total_tokens),
 				"codex-cli: subprocess failed",
 			);
+			// Surface partial usage in the error string so the scanner can
+			// still attribute spend on failed/rate-limited sessions.
+			let usage_note = partial_usage
+				.as_ref()
+				.map(|u| {
+					format!(
+						" usage={{input:{},cached_input:{},output:{},reasoning_output:{},total:{}}}",
+						u.input_tokens,
+						u.cached_input_tokens,
+						u.output_tokens,
+						u.reasoning_output_tokens,
+						u.total_tokens
+					)
+				})
+				.unwrap_or_default();
 			let combined = format!(
-				"stderr(chars={})=`{}` stdout(chars={})=`{}`",
+				"stderr(chars={})=`{}` stdout(chars={})=`{}`{}",
 				stderr_text.chars().count(),
 				summarize_cli_stream_for_error(&stderr_text, MAX_CLI_DIAGNOSTIC_CHARS),
 				stdout_text.chars().count(),
 				summarize_cli_stream_for_error(&stdout_text, MAX_CLI_DIAGNOSTIC_CHARS),
+				usage_note,
 			);
+			if let Some(rec) = &self.usage {
+				let u = partial_usage.clone().unwrap_or_default();
+				rec.record(UsageEvent {
+					ts_unix_ms: now_ms(),
+					backend: BACKEND_ID.to_owned(),
+					model: self.agent.model.clone(),
+					provider: self.agent.provider.clone(),
+					repo_id: req.repo_id,
+					job_id: req.job_id,
+					finding_id: req.finding_id,
+					file: req.usage_label.clone(),
+					ok: false,
+					elapsed_ms: started.elapsed().as_millis() as u64,
+					usage: u,
+					estimated_usd: None,
+				});
+			}
 			return Err(anyhow!("codex CLI exited with {}: {}", status, combined));
 		}
 
-		let text = String::from_utf8(stdout)
+		let raw = String::from_utf8(stdout)
 			.map_err(|e| anyhow!("codex CLI stdout was not UTF-8: {e}"))?;
+		// `--json` emits JSONL events on stdout. Pull the final agent
+		// message + cumulative token_count usage out of the stream.
+		let (text, usage) = parse_codex_jsonl(&raw);
 		if self.log_agent_output {
 			tracing::info!(
 				backend = BACKEND_ID,
-				agent_stdout = %text,
+				agent_stdout = %raw,
 				"codex-cli: agent stdout (full)"
 			);
 			if !stderr.is_empty() {
@@ -344,11 +390,28 @@ impl LlmBackend for CodexCliBackend {
 		tracing::debug!(
 			backend = BACKEND_ID,
 			elapsed_ms = started.elapsed().as_millis() as u64,
-			stdout_chars = text.chars().count(),
+			stdout_chars = raw.chars().count(),
 			stderr_chars = stderr.len(),
+			total_tokens = usage.as_ref().map(|u| u.total_tokens),
 			"codex-cli: subprocess succeeded",
 		);
-		Ok(LlmResponse { text, backend_id: BACKEND_ID })
+		if let Some(rec) = &self.usage {
+			rec.record(UsageEvent {
+				ts_unix_ms: now_ms(),
+				backend: BACKEND_ID.to_owned(),
+				model: self.agent.model.clone(),
+				provider: self.agent.provider.clone(),
+				repo_id: req.repo_id,
+				job_id: req.job_id,
+				finding_id: req.finding_id,
+				file: req.usage_label.clone(),
+				ok: true,
+				elapsed_ms: started.elapsed().as_millis() as u64,
+				usage: usage.clone().unwrap_or_default(),
+				estimated_usd: None,
+			});
+		}
+		Ok(LlmResponse { text, backend_id: BACKEND_ID, usage })
 	}
 }
 
@@ -359,6 +422,8 @@ fn codex_invocation_args(
 		"exec".to_owned(),
 		"--dangerously-bypass-approvals-and-sandbox".to_owned(),
 		"--skip-git-repo-check".to_owned(),
+		// JSONL events on stdout — required for token_count usage accounting.
+		"--json".to_owned(),
 		"--model".to_owned(),
 		agent.model.clone(),
 		"-c".to_owned(),
@@ -490,6 +555,7 @@ mod tests {
 			repo_id: None,
 			job_id: None,
 			finding_id: None,
+			usage_label: None,
 		};
 		let resp = backend.run(req).await.expect("codex responded");
 		assert_eq!(resp.backend_id, BACKEND_ID);
@@ -509,6 +575,7 @@ mod tests {
 			repo_id: None,
 			job_id: None,
 			finding_id: None,
+			usage_label: None,
 		};
 		let err = backend.run(req).await.expect_err("must error");
 		let msg = err.to_string().to_lowercase();
@@ -543,6 +610,7 @@ mod tests {
 			repo_id: None,
 			job_id: None,
 			finding_id: None,
+			usage_label: None,
 		};
 
 		let err = backend.run(req).await.expect_err("must time out");
@@ -613,6 +681,7 @@ mod tests {
 			"hello",
 		);
 
+		assert!(args.iter().any(|a| a == "--json"), "codex must emit JSONL for usage accounting");
 		assert!(args.windows(2).any(|w| w == ["--model", "gpt-test"]));
 		assert!(args.windows(2).any(|w| w == ["-c", r#"model_reasoning_effort="xhigh""#]));
 		assert!(args.windows(2).any(|w| w == ["-c", "mcp_servers.loupe.env={}"]));

--- a/crates/loupe-worker/src/llm/codex_cli.rs
+++ b/crates/loupe-worker/src/llm/codex_cli.rs
@@ -92,6 +92,8 @@ impl CodexCliBackend {
 			agent: CliModelConfig {
 				model: DEFAULT_CODEX_MODEL.to_owned(),
 				effort: DEFAULT_CODEX_EFFORT.to_owned(),
+				provider: None,
+				api_key_env: None,
 			},
 			mcp: None,
 			log_agent_output: false,
@@ -172,7 +174,21 @@ impl LlmBackend for CodexCliBackend {
 			.allow_binary(&self.bin)
 			.with_context(|| format!("preparing sandbox for `{}`", self.bin))?
 			.forward_env("OPENAI_API_KEY");
-		if let Some(api_key) = codex_api_key_env() {
+		// Resolve the auth key for THIS invocation's provider. When the
+		// agent carries an api_key_env (e.g. MOONSHOT_API_KEY for the
+		// verify role's Kimi provider), read that var from the worker's
+		// own env and inject it as CODEX_API_KEY; otherwise fall back to
+		// the default CODEX_API_KEY / OPENAI_API_KEY. codex sends the
+		// resolved value as the bearer token to the active provider's
+		// base_url, so scan (Z.AI) and verify (Moonshot) can use
+		// distinct keys.
+		let effective_api_key = self
+			.agent
+			.api_key_env
+			.as_deref()
+			.and_then(|name| std::env::var_os(name).filter(|v| !v.is_empty()))
+			.or_else(codex_api_key_env);
+		if let Some(api_key) = effective_api_key {
 			sandbox = sandbox.set_env("CODEX_API_KEY", api_key);
 		}
 		if let Some(codex_dir) = codex_home_dir() {
@@ -348,6 +364,10 @@ fn codex_invocation_args(
 		"-c".to_owned(),
 		format!("model_reasoning_effort={}", toml_string_literal(&agent.effort)),
 	];
+	if let Some(provider) = &agent.provider {
+		args.push("-c".to_owned());
+		args.push(format!("model_provider={}", toml_string_literal(provider)));
+	}
 	for ov in mcp_overrides {
 		args.push("-c".to_owned());
 		args.push(ov.clone());
@@ -583,7 +603,12 @@ mod tests {
 	#[test]
 	fn invocation_args_include_configured_model_and_effort() {
 		let args = codex_invocation_args(
-			&CliModelConfig { model: "gpt-test".into(), effort: "xhigh".into() },
+			&CliModelConfig {
+				model: "gpt-test".into(),
+				effort: "xhigh".into(),
+				provider: None,
+				api_key_env: None,
+			},
 			&["mcp_servers.loupe.env={}".to_owned()],
 			"hello",
 		);

--- a/crates/loupe-worker/src/llm/mod.rs
+++ b/crates/loupe-worker/src/llm/mod.rs
@@ -22,6 +22,7 @@ pub mod codex_cli;
 pub mod mcp;
 pub mod prompts;
 pub mod rate_limit;
+pub mod usage;
 
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -36,6 +37,7 @@ pub use codex_cli::CodexCliBackend;
 pub use mcp::{McpContext, McpTlsSource};
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
+pub use usage::{TokenUsage, UsageEvent, UsageRecorder};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CliModelConfig {
@@ -186,12 +188,19 @@ pub struct LlmRequest {
 	/// `submit_verdict`, `submit_patch`, and `validate_patch` are
 	/// advertised instead. `None` keeps the discovery-mode catalog.
 	pub finding_id: Option<i64>,
+	/// Optional human label for usage accounting (e.g. relative file
+	/// path being scanned). Stored in the usage JSONL row; not sent
+	/// to the model.
+	pub usage_label: Option<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct LlmResponse {
 	pub text: String,
 	pub backend_id: &'static str,
+	/// Token usage for this session when the backend can report it
+	/// (Codex `exec --json` token_count events). `None` when unknown.
+	pub usage: Option<TokenUsage>,
 }
 
 #[async_trait::async_trait]
@@ -312,9 +321,11 @@ fn home_path(child: &str) -> Option<PathBuf> {
 /// selection. `auto` preserves the historical behaviour: Claude owns
 /// LLM discovery when ready; Codex-only workers advertise verify-only
 /// unless the operator explicitly selects Codex for scan jobs.
+#[allow(clippy::too_many_arguments)]
 pub fn build_scan_backend(
 	mcp: Option<McpContext>, selection: JobAgent, claude_ready: bool, codex_ready: bool,
 	codex_agent: CliModelConfig, claude_agent: CliModelConfig, log_agent_output: bool,
+	usage: Option<Arc<UsageRecorder>>,
 ) -> Result<Option<Arc<dyn LlmBackend>>> {
 	match selection {
 		JobAgent::Auto if claude_ready => {
@@ -323,7 +334,7 @@ pub fn build_scan_backend(
 				effort = %claude_agent.effort,
 				"scan backend: claude (auto)"
 			);
-			Ok(Some(build_claude_backend(mcp, claude_agent, log_agent_output)))
+			Ok(Some(build_claude_backend(mcp, claude_agent, log_agent_output, usage)))
 		},
 		JobAgent::Auto => {
 			tracing::info!(
@@ -338,7 +349,7 @@ pub fn build_scan_backend(
 				effort = %claude_agent.effort,
 				"scan backend: claude (configured)"
 			);
-			Ok(Some(build_claude_backend(mcp, claude_agent, log_agent_output)))
+			Ok(Some(build_claude_backend(mcp, claude_agent, log_agent_output, usage)))
 		},
 		JobAgent::Codex => {
 			require_agent_ready("scan", JobAgent::Codex, codex_ready)?;
@@ -347,7 +358,7 @@ pub fn build_scan_backend(
 				effort = %codex_agent.effort,
 				"scan backend: codex (configured)"
 			);
-			Ok(Some(build_codex_backend(mcp, codex_agent, log_agent_output)))
+			Ok(Some(build_codex_backend(mcp, codex_agent, log_agent_output, usage)))
 		},
 	}
 }
@@ -366,9 +377,11 @@ pub fn build_scan_backend(
 ///
 /// Logs the choice at info level so operators can see which backend
 /// is actually verifying without having to inspect process listings.
+#[allow(clippy::too_many_arguments)]
 pub fn build_verifier_backend(
 	mcp: Option<McpContext>, selection: JobAgent, claude_ready: bool, codex_ready: bool,
 	codex_agent: CliModelConfig, claude_agent: CliModelConfig, log_agent_output: bool,
+	usage: Option<Arc<UsageRecorder>>,
 ) -> Result<Arc<dyn LlmBackend>> {
 	match selection {
 		JobAgent::Auto if codex_ready => {
@@ -377,7 +390,7 @@ pub fn build_verifier_backend(
 				effort = %codex_agent.effort,
 				"verifier backend: codex (auto)"
 			);
-			Ok(build_codex_backend(mcp, codex_agent, log_agent_output))
+			Ok(build_codex_backend(mcp, codex_agent, log_agent_output, usage.clone()))
 		},
 		JobAgent::Auto if claude_ready => {
 			tracing::info!(
@@ -385,7 +398,7 @@ pub fn build_verifier_backend(
 				effort = %claude_agent.effort,
 				"verifier backend: claude (auto, codex unavailable)"
 			);
-			Ok(build_claude_backend(mcp, claude_agent, log_agent_output))
+			Ok(build_claude_backend(mcp, claude_agent, log_agent_output, usage.clone()))
 		},
 		JobAgent::Auto => anyhow::bail!("no authenticated verifier backend available"),
 		JobAgent::Claude => {
@@ -395,7 +408,7 @@ pub fn build_verifier_backend(
 				effort = %claude_agent.effort,
 				"verifier backend: claude (configured)"
 			);
-			Ok(build_claude_backend(mcp, claude_agent, log_agent_output))
+			Ok(build_claude_backend(mcp, claude_agent, log_agent_output, usage.clone()))
 		},
 		JobAgent::Codex => {
 			require_agent_ready("verify", JobAgent::Codex, codex_ready)?;
@@ -404,7 +417,7 @@ pub fn build_verifier_backend(
 				effort = %codex_agent.effort,
 				"verifier backend: codex (configured)"
 			);
-			Ok(build_codex_backend(mcp, codex_agent, log_agent_output))
+			Ok(build_codex_backend(mcp, codex_agent, log_agent_output, usage.clone()))
 		},
 	}
 }
@@ -421,22 +434,30 @@ fn require_agent_ready(job_kind: &str, agent: JobAgent, ready: bool) -> Result<(
 
 fn build_claude_backend(
 	mcp: Option<McpContext>, agent: CliModelConfig, log_agent_output: bool,
+	usage: Option<Arc<UsageRecorder>>,
 ) -> Arc<dyn LlmBackend> {
 	let mut backend =
 		ClaudeCliBackend::new().with_agent_config(agent).with_log_agent_output(log_agent_output);
 	if let Some(ctx) = mcp {
 		backend = backend.with_mcp_context(ctx);
 	}
+	if let Some(u) = usage {
+		backend = backend.with_usage_recorder(u);
+	}
 	Arc::new(backend)
 }
 
 fn build_codex_backend(
 	mcp: Option<McpContext>, agent: CliModelConfig, log_agent_output: bool,
+	usage: Option<Arc<UsageRecorder>>,
 ) -> Arc<dyn LlmBackend> {
 	let mut backend =
 		CodexCliBackend::new().with_agent_config(agent).with_log_agent_output(log_agent_output);
 	if let Some(ctx) = mcp {
 		backend = backend.with_mcp_context(ctx);
+	}
+	if let Some(u) = usage {
+		backend = backend.with_usage_recorder(u);
 	}
 	Arc::new(backend)
 }
@@ -555,6 +576,7 @@ mod tests {
 			codex.clone(),
 			claude.clone(),
 			false,
+			None,
 		)
 		.unwrap()
 		.expect("claude-ready auto scan should register");
@@ -568,6 +590,7 @@ mod tests {
 			codex.clone(),
 			claude,
 			false,
+			None,
 		)
 		.unwrap();
 		assert!(
@@ -599,6 +622,7 @@ mod tests {
 			codex.clone(),
 			claude.clone(),
 			false,
+			None,
 		)
 		.unwrap()
 		.expect("explicit codex scan should register when codex is ready");
@@ -612,6 +636,7 @@ mod tests {
 			codex,
 			claude,
 			false,
+			None,
 		) {
 			Ok(_) => panic!("explicit unavailable codex scan should fail"),
 			Err(e) => e,
@@ -641,6 +666,7 @@ mod tests {
 			codex.clone(),
 			claude.clone(),
 			false,
+			None,
 		)
 		.unwrap();
 		assert_eq!(backend.id(), "codex-cli");
@@ -653,6 +679,7 @@ mod tests {
 			codex.clone(),
 			claude.clone(),
 			false,
+			None,
 		)
 		.unwrap();
 		assert_eq!(backend.id(), "claude-cli");
@@ -665,6 +692,7 @@ mod tests {
 			codex,
 			claude,
 			false,
+			None,
 		) {
 			Ok(_) => panic!("missing verifier backend should be rejected"),
 			Err(e) => e,
@@ -695,6 +723,7 @@ mod tests {
 			codex.clone(),
 			claude.clone(),
 			false,
+			None,
 		)
 		.unwrap();
 		assert_eq!(backend.id(), "claude-cli");
@@ -707,6 +736,7 @@ mod tests {
 			codex,
 			claude,
 			false,
+			None,
 		) {
 			Ok(_) => panic!("explicit unavailable claude verifier should fail"),
 			Err(e) => e,
@@ -789,7 +819,7 @@ pub mod testing {
 
 		async fn run(&self, req: LlmRequest) -> Result<LlmResponse> {
 			let text = (self.f)(req).await?;
-			Ok(LlmResponse { text, backend_id: self.id })
+			Ok(LlmResponse { text, backend_id: self.id, usage: None })
 		}
 	}
 }

--- a/crates/loupe-worker/src/llm/mod.rs
+++ b/crates/loupe-worker/src/llm/mod.rs
@@ -40,6 +40,19 @@ use tokio_util::sync::CancellationToken;
 pub struct CliModelConfig {
 	pub model: String,
 	pub effort: String,
+	/// Optional Codex `model_provider` override. When set, every codex
+	/// invocation emits `-c model_provider=<provider>` so two roles that
+	/// share the codex backend can target different OpenAI-compatible
+	/// providers (e.g. scan -> Z.AI GLM, verify -> Moonshot Kimi).
+	/// Ignored by the claude backend.
+	pub provider: Option<String>,
+	/// Optional name of an env var (read from the worker's own
+	/// environment) whose value is injected as CODEX_API_KEY for
+	/// this codex invocation. Routes a distinct API key per provider
+	/// (e.g. MOONSHOT_API_KEY for the verify role's Kimi provider)
+	/// without relying on codex's per-provider env_key support. None
+	/// falls back to CODEX_API_KEY / OPENAI_API_KEY.
+	pub api_key_env: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, ValueEnum)]
@@ -520,8 +533,18 @@ mod tests {
 
 	#[test]
 	fn scan_backend_auto_preserves_claude_only_discovery_default() {
-		let codex = CliModelConfig { model: "gpt-test".into(), effort: "xhigh".into() };
-		let claude = CliModelConfig { model: "claude-test".into(), effort: "max".into() };
+		let codex = CliModelConfig {
+			model: "gpt-test".into(),
+			effort: "xhigh".into(),
+			provider: None,
+			api_key_env: None,
+		};
+		let claude = CliModelConfig {
+			model: "claude-test".into(),
+			effort: "max".into(),
+			provider: None,
+			api_key_env: None,
+		};
 
 		let backend = build_scan_backend(
 			None,
@@ -536,9 +559,16 @@ mod tests {
 		.expect("claude-ready auto scan should register");
 		assert_eq!(backend.id(), "claude-cli");
 
-		let backend =
-			build_scan_backend(None, JobAgent::Auto, false, true, codex.clone(), claude, false)
-				.unwrap();
+		let backend = build_scan_backend(
+			None,
+			JobAgent::Auto,
+			false,
+			true,
+			codex.clone(),
+			claude,
+			false,
+		)
+		.unwrap();
 		assert!(
 			backend.is_none(),
 			"auto scan should not switch to codex unless explicitly configured"
@@ -547,8 +577,18 @@ mod tests {
 
 	#[test]
 	fn scan_backend_allows_explicit_codex_and_fails_when_unavailable() {
-		let codex = CliModelConfig { model: "gpt-test".into(), effort: "xhigh".into() };
-		let claude = CliModelConfig { model: "claude-test".into(), effort: "max".into() };
+		let codex = CliModelConfig {
+			model: "gpt-test".into(),
+			effort: "xhigh".into(),
+			provider: None,
+			api_key_env: None,
+		};
+		let claude = CliModelConfig {
+			model: "claude-test".into(),
+			effort: "max".into(),
+			provider: None,
+			api_key_env: None,
+		};
 
 		let backend = build_scan_backend(
 			None,
@@ -563,8 +603,15 @@ mod tests {
 		.expect("explicit codex scan should register when codex is ready");
 		assert_eq!(backend.id(), "codex-cli");
 
-		let err = match build_scan_backend(None, JobAgent::Codex, true, false, codex, claude, false)
-		{
+		let err = match build_scan_backend(
+			None,
+			JobAgent::Codex,
+			true,
+			false,
+			codex,
+			claude,
+			false,
+		) {
 			Ok(_) => panic!("explicit unavailable codex scan should fail"),
 			Err(e) => e,
 		};
@@ -573,8 +620,18 @@ mod tests {
 
 	#[test]
 	fn verifier_backend_auto_prefers_codex_then_claude() {
-		let codex = CliModelConfig { model: "gpt-test".into(), effort: "xhigh".into() };
-		let claude = CliModelConfig { model: "claude-test".into(), effort: "max".into() };
+		let codex = CliModelConfig {
+			model: "gpt-test".into(),
+			effort: "xhigh".into(),
+			provider: None,
+			api_key_env: None,
+		};
+		let claude = CliModelConfig {
+			model: "claude-test".into(),
+			effort: "max".into(),
+			provider: None,
+			api_key_env: None,
+		};
 		let backend = build_verifier_backend(
 			None,
 			JobAgent::Auto,
@@ -616,8 +673,18 @@ mod tests {
 
 	#[test]
 	fn verifier_backend_honors_explicit_selection() {
-		let codex = CliModelConfig { model: "gpt-test".into(), effort: "xhigh".into() };
-		let claude = CliModelConfig { model: "claude-test".into(), effort: "max".into() };
+		let codex = CliModelConfig {
+			model: "gpt-test".into(),
+			effort: "xhigh".into(),
+			provider: None,
+			api_key_env: None,
+		};
+		let claude = CliModelConfig {
+			model: "claude-test".into(),
+			effort: "max".into(),
+			provider: None,
+			api_key_env: None,
+		};
 
 		let backend = build_verifier_backend(
 			None,
@@ -631,12 +698,18 @@ mod tests {
 		.unwrap();
 		assert_eq!(backend.id(), "claude-cli");
 
-		let err =
-			match build_verifier_backend(None, JobAgent::Claude, false, true, codex, claude, false)
-			{
-				Ok(_) => panic!("explicit unavailable claude verifier should fail"),
-				Err(e) => e,
-			};
+		let err = match build_verifier_backend(
+			None,
+			JobAgent::Claude,
+			false,
+			true,
+			codex,
+			claude,
+			false,
+		) {
+			Ok(_) => panic!("explicit unavailable claude verifier should fail"),
+			Err(e) => e,
+		};
 		assert!(err.to_string().contains("verify agent `claude`"), "got: {err}");
 	}
 }

--- a/crates/loupe-worker/src/llm/mod.rs
+++ b/crates/loupe-worker/src/llm/mod.rs
@@ -21,6 +21,7 @@ pub mod claude_cli;
 pub mod codex_cli;
 pub mod mcp;
 pub mod prompts;
+pub mod rate_limit;
 
 use std::ffi::OsString;
 use std::path::PathBuf;

--- a/crates/loupe-worker/src/llm/rate_limit.rs
+++ b/crates/loupe-worker/src/llm/rate_limit.rs
@@ -1,0 +1,351 @@
+//! Adaptive concurrency + backoff for LLM provider rate limits.
+//!
+//! Codex (and other CLIs) surface upstream 429s as process failures after
+//! their own internal retries are exhausted, typically:
+//!
+//!   ERROR: exceeded retry limit, last status: 429 Too Many Requests
+//!
+//! The discovery scanner fans out one agent session per source file. Without
+//! coordination, N concurrent sessions all thrash the same quota, burn the
+//! retry budget, and fail every file. This module:
+//!
+//! 1. Classifies rate-limit / retry-limit errors from CLI stderr/stdout.
+//! 2. Provides a dynamic permit pool ([`AdaptiveConcurrency`]) that shrinks
+//!    on rate limits, sleeps with exponential backoff, and slowly recovers
+//!    on success.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tokio::sync::Notify;
+
+/// Base backoff after the first rate-limit hit. Doubles per consecutive hit
+/// up to [`MAX_BACKOFF`].
+const BASE_BACKOFF: Duration = Duration::from_secs(20);
+/// Cap so a stuck provider doesn't park the worker for an hour.
+const MAX_BACKOFF: Duration = Duration::from_secs(5 * 60);
+/// Consecutive rate-limit hits used for the exponential shift (2^n).
+const MAX_BACKOFF_EXPONENT: u32 = 5;
+
+/// Return true when an LLM backend error looks like an upstream rate limit
+/// or exhausted provider retry budget. Matching is intentionally loose —
+/// codex, claude, and OpenAI-compatible proxies phrase the same condition
+/// slightly differently, and the actionable text often sits at the tail of
+/// a long CLI banner (see [`super::summarize_cli_stream_for_error`]).
+pub fn is_rate_limit_error(err: &anyhow::Error) -> bool {
+	is_rate_limit_message(&format!("{err:#}"))
+}
+
+/// String-level classifier used by [`is_rate_limit_error`] and unit tests.
+pub fn is_rate_limit_message(msg: &str) -> bool {
+	let lower = msg.to_ascii_lowercase();
+	// Order: cheap specific markers first, then broader phrases.
+	lower.contains("429")
+		|| lower.contains("too many requests")
+		|| lower.contains("exceeded retry limit")
+		|| lower.contains("retry limit")
+		|| lower.contains("rate limit")
+		|| lower.contains("rate-limit")
+		|| lower.contains("rate_limit")
+		|| lower.contains("ratelimit")
+		|| lower.contains("quota exceeded")
+		|| lower.contains("resource has been exhausted")
+		|| lower.contains("tokens per day")
+		|| lower.contains("tokens per minute")
+		|| lower.contains("requests per minute")
+}
+
+#[derive(Debug)]
+struct BackoffState {
+	/// Consecutive rate-limit observations since the last success.
+	consecutive: u32,
+	/// When set and in the future, [`AdaptiveConcurrency::acquire`] sleeps
+	/// until this instant before handing out a new permit.
+	cooldown_until: Option<Instant>,
+}
+
+/// Dynamic concurrency limiter shared across the per-file agent fan-out.
+///
+/// - Starts at `max` concurrent permits (the configured
+///   `max_concurrent_files`).
+/// - On rate limit: halves the limit (floor 1), records exponential
+///   cooldown, wakes waiters so they observe the new ceiling.
+/// - On success: clears the consecutive counter and nudges the limit up
+///   by 1 (capped at `max`) once any cooldown has elapsed.
+/// - [`Ticket`] RAII releases the in-flight slot on drop.
+pub struct AdaptiveConcurrency {
+	max: usize,
+	limit: AtomicUsize,
+	in_flight: AtomicUsize,
+	notify: Notify,
+	state: Mutex<BackoffState>,
+}
+
+/// RAII permit. Dropping it decrements `in_flight` and wakes a waiter.
+pub struct Ticket {
+	parent: Arc<AdaptiveConcurrency>,
+}
+
+impl Drop for Ticket {
+	fn drop(&mut self) {
+		self.parent.in_flight.fetch_sub(1, Ordering::AcqRel);
+		self.parent.notify.notify_waiters();
+	}
+}
+
+impl AdaptiveConcurrency {
+	pub fn new(max: usize) -> Arc<Self> {
+		let max = max.max(1);
+		Arc::new(Self {
+			max,
+			limit: AtomicUsize::new(max),
+			in_flight: AtomicUsize::new(0),
+			notify: Notify::new(),
+			state: Mutex::new(BackoffState { consecutive: 0, cooldown_until: None }),
+		})
+	}
+
+	/// Current concurrency ceiling (1..=max). Exposed for logs/tests.
+	pub fn current_limit(&self) -> usize {
+		self.limit.load(Ordering::Acquire).clamp(1, self.max)
+	}
+
+	pub fn max(&self) -> usize {
+		self.max
+	}
+
+	/// Wait until a permit is available and any cooldown has elapsed.
+	pub async fn acquire(self: &Arc<Self>) -> Ticket {
+		loop {
+			// Honour cooldown first so we don't spin-acquire during backoff.
+			let sleep_for = {
+				let st = self.state.lock().expect("rate-limit state lock");
+				st.cooldown_until.and_then(|until| {
+					let now = Instant::now();
+					if until > now {
+						Some(until - now)
+					} else {
+						None
+					}
+				})
+			};
+			if let Some(delay) = sleep_for {
+				tokio::time::sleep(delay).await;
+				// Clear expired cooldown so success recovery can run.
+				let mut st = self.state.lock().expect("rate-limit state lock");
+				if st.cooldown_until.is_some_and(|u| u <= Instant::now()) {
+					st.cooldown_until = None;
+				}
+				continue;
+			}
+
+			// Register the waiter BEFORE re-checking so a release between
+			// the check and the await can't be missed (`notify_waiters`
+			// only wakes registered waiters; without `enable` we'd risk a
+			// lost wakeup and a stalled scan).
+			let notified = self.notify.notified();
+			tokio::pin!(notified);
+			notified.as_mut().enable();
+
+			let limit = self.current_limit();
+			let prev = self.in_flight.fetch_add(1, Ordering::AcqRel);
+			if prev < limit {
+				return Ticket { parent: Arc::clone(self) };
+			}
+			// Lost the race — roll back and wait for a release / limit change.
+			self.in_flight.fetch_sub(1, Ordering::AcqRel);
+			notified.await;
+		}
+	}
+
+	/// A session completed cleanly. Reset consecutive rate-limit count and
+	/// slowly restore concurrency once we're outside a cooldown window.
+	pub fn record_success(&self) {
+		let mut st = self.state.lock().expect("rate-limit state lock");
+		st.consecutive = 0;
+		let cooling = st.cooldown_until.is_some_and(|u| u > Instant::now());
+		if cooling {
+			return;
+		}
+		st.cooldown_until = None;
+		let cur = self.current_limit();
+		if cur < self.max {
+			let next = (cur + 1).min(self.max);
+			self.limit.store(next, Ordering::Release);
+			tracing::info!(
+				previous = cur,
+				limit = next,
+				max = self.max,
+				"llm rate-limit: restored concurrency after success"
+			);
+			self.notify.notify_waiters();
+		}
+	}
+
+	/// A session hit a provider rate limit. Shrink concurrency and arm
+	/// exponential backoff so the rest of the fan-out slows down.
+	pub fn record_rate_limit(&self, detail: &str) {
+		let mut st = self.state.lock().expect("rate-limit state lock");
+		st.consecutive = st.consecutive.saturating_add(1).min(MAX_BACKOFF_EXPONENT + 1);
+		let exponent = st.consecutive.saturating_sub(1).min(MAX_BACKOFF_EXPONENT);
+		let mut delay = BASE_BACKOFF.saturating_mul(1u32 << exponent);
+		if delay > MAX_BACKOFF {
+			delay = MAX_BACKOFF;
+		}
+		let until = Instant::now() + delay;
+		st.cooldown_until = Some(match st.cooldown_until {
+			Some(existing) if existing > until => existing,
+			_ => until,
+		});
+
+		let cur = self.current_limit();
+		// Floor at 1 so we keep making progress, just slowly.
+		let next = (cur / 2).max(1);
+		self.limit.store(next, Ordering::Release);
+
+		tracing::warn!(
+			previous = cur,
+			limit = next,
+			max = self.max,
+			consecutive = st.consecutive,
+			backoff_secs = delay.as_secs(),
+			detail = %truncate_for_log(detail, 240),
+			"llm rate-limit: slowing fan-out (reduced concurrency + backoff)"
+		);
+		// Wake acquire() waiters so they re-check cooldown/limit instead of
+		// sitting on a stale notified edge.
+		self.notify.notify_waiters();
+	}
+
+	/// Non-rate-limit failure: leave concurrency alone. (Auth errors, MCP
+	/// crashes, etc. aren't fixed by going slower.)
+	pub fn record_other_error(&self) {
+		// Intentionally empty — kept as an explicit hook so call sites
+		// document the three-way outcome (success / rate-limit / other).
+	}
+}
+
+fn truncate_for_log(s: &str, max_chars: usize) -> String {
+	let collapsed = s.split_whitespace().collect::<Vec<_>>().join(" ");
+	if collapsed.chars().count() <= max_chars {
+		return collapsed;
+	}
+	let mut out: String = collapsed.chars().take(max_chars.saturating_sub(3)).collect();
+	out.push_str("...");
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn classifies_codex_retry_limit_429() {
+		let msg = "codex CLI exited with exit status: 1: stderr(chars=200)=\
+			`ERROR: exceeded retry limit, last status: 429 Too Many Requests`";
+		assert!(is_rate_limit_message(msg));
+	}
+
+	#[test]
+	fn classifies_plain_rate_limit_phrases() {
+		assert!(is_rate_limit_message("Rate limit exceeded, please retry later"));
+		assert!(is_rate_limit_message("resource_exhausted: quota exceeded"));
+		assert!(is_rate_limit_message("TPM: tokens per minute limit hit"));
+	}
+
+	#[test]
+	fn ignores_unrelated_errors() {
+		assert!(!is_rate_limit_message("codex CLI exited with exit status: 1: auth failed"));
+		assert!(!is_rate_limit_message("mcp startup: failed: loupe handshaking failed"));
+		assert!(!is_rate_limit_message("timed out after 30s"));
+	}
+
+	#[test]
+	fn rate_limit_halves_concurrency_and_sets_cooldown() {
+		let c = AdaptiveConcurrency::new(8);
+		assert_eq!(c.current_limit(), 8);
+		c.record_rate_limit("429 Too Many Requests");
+		assert_eq!(c.current_limit(), 4);
+		c.record_rate_limit("exceeded retry limit");
+		assert_eq!(c.current_limit(), 2);
+		c.record_rate_limit("429");
+		assert_eq!(c.current_limit(), 1);
+		// Floor stays at 1.
+		c.record_rate_limit("429");
+		assert_eq!(c.current_limit(), 1);
+
+		let st = c.state.lock().unwrap();
+		assert!(st.consecutive >= 4);
+		assert!(st.cooldown_until.is_some_and(|u| u > Instant::now()));
+	}
+
+	#[test]
+	fn success_restores_concurrency_after_cooldown_clears() {
+		let c = AdaptiveConcurrency::new(4);
+		c.record_rate_limit("429");
+		assert_eq!(c.current_limit(), 2);
+		// Simulate cooldown already elapsed.
+		{
+			let mut st = c.state.lock().unwrap();
+			st.cooldown_until = Some(Instant::now() - Duration::from_secs(1));
+		}
+		c.record_success();
+		assert_eq!(c.current_limit(), 3);
+		c.record_success();
+		assert_eq!(c.current_limit(), 4);
+		// Capped at max.
+		c.record_success();
+		assert_eq!(c.current_limit(), 4);
+	}
+
+	#[test]
+	fn success_does_not_restore_during_active_cooldown() {
+		let c = AdaptiveConcurrency::new(4);
+		c.record_rate_limit("429");
+		assert_eq!(c.current_limit(), 2);
+		c.record_success();
+		// Still cooling down — limit stays put.
+		assert_eq!(c.current_limit(), 2);
+	}
+
+	#[tokio::test]
+	async fn acquire_respects_limit() {
+		let c = AdaptiveConcurrency::new(2);
+		let t1 = c.acquire().await;
+		let t2 = c.acquire().await;
+		assert_eq!(c.in_flight.load(Ordering::Acquire), 2);
+
+		// Third acquire should not complete until a ticket drops.
+		let c3 = Arc::clone(&c);
+		let third = tokio::spawn(async move { c3.acquire().await });
+		tokio::time::sleep(Duration::from_millis(30)).await;
+		assert!(!third.is_finished());
+
+		drop(t1);
+		let t3 = tokio::time::timeout(Duration::from_secs(1), third)
+			.await
+			.expect("join")
+			.expect("third acquire");
+		assert_eq!(c.in_flight.load(Ordering::Acquire), 2);
+		drop(t2);
+		drop(t3);
+	}
+
+	#[tokio::test]
+	async fn acquire_waits_out_cooldown() {
+		let c = AdaptiveConcurrency::new(2);
+		{
+			let mut st = c.state.lock().unwrap();
+			st.cooldown_until = Some(Instant::now() + Duration::from_millis(80));
+			st.consecutive = 1;
+		}
+		let started = Instant::now();
+		let _t = c.acquire().await;
+		assert!(
+			started.elapsed() >= Duration::from_millis(60),
+			"acquire returned before cooldown elapsed: {:?}",
+			started.elapsed()
+		);
+	}
+}

--- a/crates/loupe-worker/src/llm/usage.rs
+++ b/crates/loupe-worker/src/llm/usage.rs
@@ -1,0 +1,420 @@
+//! LLM token-usage accounting for funding / capacity planning.
+//!
+//! Codex `exec --json` emits `event_msg.token_count` events with
+//! cumulative `total_token_usage` for the session. We parse those,
+//! attach them to [`LlmResponse`], and append durable JSONL rows under
+//! the worker cache so operators can answer "how many tokens did we
+//! burn this week?" without scraping provider dashboards.
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+/// Token counters for one agent session (one file scan / one verify).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenUsage {
+	pub input_tokens: u64,
+	pub cached_input_tokens: u64,
+	pub output_tokens: u64,
+	pub reasoning_output_tokens: u64,
+	pub total_tokens: u64,
+}
+
+impl TokenUsage {
+	pub fn is_zero(&self) -> bool {
+		self.total_tokens == 0
+			&& self.input_tokens == 0
+			&& self.output_tokens == 0
+			&& self.cached_input_tokens == 0
+			&& self.reasoning_output_tokens == 0
+	}
+
+	/// Prefer the richer cumulative snapshot when multiple token_count
+	/// events arrive in one session (Codex reports running totals).
+	pub fn prefer_richer(self, other: Self) -> Self {
+		if other.total_tokens >= self.total_tokens {
+			other
+		} else {
+			self
+		}
+	}
+}
+
+/// One append-only row written under `usage/llm-usage.jsonl`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageEvent {
+	pub ts_unix_ms: u64,
+	pub backend: String,
+	pub model: String,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub provider: Option<String>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub repo_id: Option<i64>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub job_id: Option<i64>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub finding_id: Option<i64>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub file: Option<String>,
+	pub ok: bool,
+	pub elapsed_ms: u64,
+	#[serde(flatten)]
+	pub usage: TokenUsage,
+	/// Best-effort USD estimate when unit prices are configured.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub estimated_usd: Option<f64>,
+}
+
+/// Process-wide recorder. Appends JSONL and keeps running totals for logs.
+pub struct UsageRecorder {
+	jsonl_path: PathBuf,
+	summary_path: PathBuf,
+	write_lock: Mutex<()>,
+	sessions: AtomicU64,
+	total_tokens: AtomicU64,
+	input_tokens: AtomicU64,
+	output_tokens: AtomicU64,
+	/// Optional default USD / 1M tokens used when no per-model price matches.
+	default_input_usd_per_mtok: Option<f64>,
+	default_output_usd_per_mtok: Option<f64>,
+}
+
+impl UsageRecorder {
+	pub fn open(cache_dir: &Path) -> anyhow::Result<Arc<Self>> {
+		let dir = cache_dir.join("usage");
+		std::fs::create_dir_all(&dir)?;
+		let jsonl_path = dir.join("llm-usage.jsonl");
+		let summary_path = dir.join("llm-usage-summary.json");
+		// Optional crude pricing via env so funding estimates work without a
+		// config-schema bump. Values are USD per 1M tokens.
+		let default_input_usd_per_mtok =
+			std::env::var("LOUPE_USAGE_INPUT_USD_PER_MTOK").ok().and_then(|s| s.parse().ok());
+		let default_output_usd_per_mtok =
+			std::env::var("LOUPE_USAGE_OUTPUT_USD_PER_MTOK").ok().and_then(|s| s.parse().ok());
+		let me = Arc::new(Self {
+			jsonl_path,
+			summary_path,
+			write_lock: Mutex::new(()),
+			sessions: AtomicU64::new(0),
+			total_tokens: AtomicU64::new(0),
+			input_tokens: AtomicU64::new(0),
+			output_tokens: AtomicU64::new(0),
+			default_input_usd_per_mtok,
+			default_output_usd_per_mtok,
+		});
+		// Seed in-memory totals from any existing JSONL so restarts don't
+		// zero the funding counters operators already paid for.
+		if let Err(e) = me.hydrate_from_disk() {
+			tracing::warn!(error = %e, path = %me.jsonl_path.display(), "usage: could not hydrate prior totals");
+		}
+		tracing::info!(
+			path = %me.jsonl_path.display(),
+			sessions = me.sessions.load(Ordering::Relaxed),
+			total_tokens = me.total_tokens.load(Ordering::Relaxed),
+			"usage: recorder ready (JSONL + summary)"
+		);
+		Ok(me)
+	}
+
+	pub fn jsonl_path(&self) -> &Path {
+		&self.jsonl_path
+	}
+
+	fn hydrate_from_disk(&self) -> anyhow::Result<()> {
+		if !self.jsonl_path.exists() {
+			return Ok(());
+		}
+		let text = std::fs::read_to_string(&self.jsonl_path)?;
+		let mut sessions = 0u64;
+		let mut input_tokens = 0u64;
+		let mut output_tokens = 0u64;
+		let mut total_tokens = 0u64;
+		for line in text.lines() {
+			let line = line.trim();
+			if line.is_empty() {
+				continue;
+			}
+			let ev: UsageEvent = match serde_json::from_str(line) {
+				Ok(v) => v,
+				Err(_) => continue,
+			};
+			sessions += 1;
+			input_tokens = input_tokens.saturating_add(ev.usage.input_tokens);
+			output_tokens = output_tokens
+				.saturating_add(ev.usage.output_tokens)
+				.saturating_add(ev.usage.reasoning_output_tokens);
+			total_tokens = total_tokens.saturating_add(ev.usage.total_tokens);
+		}
+		self.sessions.store(sessions, Ordering::Relaxed);
+		self.total_tokens.store(total_tokens, Ordering::Relaxed);
+		self.input_tokens.store(input_tokens, Ordering::Relaxed);
+		self.output_tokens.store(output_tokens, Ordering::Relaxed);
+		Ok(())
+	}
+
+	pub fn estimate_usd(&self, usage: &TokenUsage) -> Option<f64> {
+		let (Some(inp), Some(out)) =
+			(self.default_input_usd_per_mtok, self.default_output_usd_per_mtok)
+		else {
+			return None;
+		};
+		// Bill uncached input + all output (incl. reasoning) at the output rate
+		// when we lack a separate reasoning price. Cached input is treated as
+		// free/cheap (0) unless operators set a dedicated price later.
+		let uncached_input = usage.input_tokens.saturating_sub(usage.cached_input_tokens);
+		let billable_output = usage.output_tokens.saturating_add(usage.reasoning_output_tokens);
+		let usd = (uncached_input as f64) / 1_000_000.0 * inp
+			+ (billable_output as f64) / 1_000_000.0 * out;
+		Some(usd)
+	}
+
+	pub fn record(&self, mut event: UsageEvent) {
+		if event.estimated_usd.is_none() {
+			event.estimated_usd = self.estimate_usd(&event.usage);
+		}
+		self.sessions.fetch_add(1, Ordering::Relaxed);
+		self.total_tokens.fetch_add(event.usage.total_tokens, Ordering::Relaxed);
+		self.input_tokens.fetch_add(event.usage.input_tokens, Ordering::Relaxed);
+		self.output_tokens.fetch_add(
+			event.usage.output_tokens.saturating_add(event.usage.reasoning_output_tokens),
+			Ordering::Relaxed,
+		);
+
+		let line = match serde_json::to_string(&event) {
+			Ok(s) => s,
+			Err(e) => {
+				tracing::warn!(error = %e, "usage: failed to serialise event");
+				return;
+			},
+		};
+
+		let _guard = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+		if let Err(e) = (|| -> anyhow::Result<()> {
+			let mut f = OpenOptions::new().create(true).append(true).open(&self.jsonl_path)?;
+			f.write_all(line.as_bytes())?;
+			f.write_all(b"\n")?;
+			f.flush()?;
+			// Rewrite a small summary snapshot for humans / funding decks.
+			let summary = serde_json::json!({
+				"updated_ts_unix_ms": now_ms(),
+				"sessions": self.sessions.load(Ordering::Relaxed),
+				"input_tokens": self.input_tokens.load(Ordering::Relaxed),
+				"output_tokens": self.output_tokens.load(Ordering::Relaxed),
+				"total_tokens": self.total_tokens.load(Ordering::Relaxed),
+				"jsonl_path": self.jsonl_path.display().to_string(),
+				"note": "Totals are cumulative across worker restarts (hydrated from JSONL). Set LOUPE_USAGE_INPUT_USD_PER_MTOK / LOUPE_USAGE_OUTPUT_USD_PER_MTOK for USD estimates.",
+			});
+			let tmp = self.summary_path.with_extension("json.tmp");
+			let mut sf = File::create(&tmp)?;
+			sf.write_all(serde_json::to_string_pretty(&summary)?.as_bytes())?;
+			sf.write_all(b"\n")?;
+			sf.flush()?;
+			std::fs::rename(&tmp, &self.summary_path)?;
+			Ok(())
+		})() {
+			tracing::warn!(error = %e, path = %self.jsonl_path.display(), "usage: failed to persist event");
+		}
+
+		tracing::info!(
+			backend = %event.backend,
+			model = %event.model,
+			provider = ?event.provider,
+			repo_id = ?event.repo_id,
+			job_id = ?event.job_id,
+			file = ?event.file,
+			ok = event.ok,
+			input_tokens = event.usage.input_tokens,
+			cached_input_tokens = event.usage.cached_input_tokens,
+			output_tokens = event.usage.output_tokens,
+			reasoning_output_tokens = event.usage.reasoning_output_tokens,
+			total_tokens = event.usage.total_tokens,
+			estimated_usd = ?event.estimated_usd,
+			cumulative_total_tokens = self.total_tokens.load(Ordering::Relaxed),
+			cumulative_sessions = self.sessions.load(Ordering::Relaxed),
+			"usage: session recorded"
+		);
+	}
+}
+
+pub fn now_ms() -> u64 {
+	SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as u64).unwrap_or(0)
+}
+
+/// Parse Codex `exec --json` JSONL stdout into (final text, token usage).
+///
+/// Usage: take the richest `payload.info.total_token_usage` across all
+/// `token_count` events (Codex emits running session totals).
+/// Text: last `agent_message` (prefer `phase == "final"` when present),
+/// falling back to `task_complete.last_agent_message`.
+pub fn parse_codex_jsonl(stdout: &str) -> (String, Option<TokenUsage>) {
+	let mut usage = TokenUsage::default();
+	let mut saw_usage = false;
+	let mut last_msg: Option<String> = None;
+	let mut last_final: Option<String> = None;
+	let mut task_complete_msg: Option<String> = None;
+
+	for line in stdout.lines() {
+		let line = line.trim();
+		if line.is_empty() {
+			continue;
+		}
+		let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+			continue;
+		};
+		let typ = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+		if typ != "event_msg" {
+			continue;
+		}
+		let Some(payload) = v.get("payload") else { continue };
+		let ptype = payload.get("type").and_then(|t| t.as_str()).unwrap_or("");
+		match ptype {
+			"token_count" => {
+				if let Some(u) = extract_total_token_usage(payload) {
+					usage = if saw_usage { usage.prefer_richer(u) } else { u };
+					saw_usage = true;
+				}
+			},
+			"agent_message" => {
+				if let Some(msg) = payload.get("message").and_then(|m| m.as_str()) {
+					let phase = payload.get("phase").and_then(|p| p.as_str()).unwrap_or("");
+					if phase == "final" {
+						last_final = Some(msg.to_owned());
+					}
+					last_msg = Some(msg.to_owned());
+				}
+			},
+			"task_complete" => {
+				if let Some(msg) = payload.get("last_agent_message").and_then(|m| m.as_str()) {
+					task_complete_msg = Some(msg.to_owned());
+				}
+			},
+			_ => {},
+		}
+	}
+
+	let text = last_final.or(last_msg).or(task_complete_msg).unwrap_or_default();
+	(text, if saw_usage { Some(usage) } else { None })
+}
+
+fn extract_total_token_usage(payload: &serde_json::Value) -> Option<TokenUsage> {
+	let info = payload.get("info")?;
+	// Prefer cumulative total_token_usage; fall back to last_token_usage.
+	let u = info
+		.get("total_token_usage")
+		.or_else(|| info.get("last_token_usage"))
+		.or_else(|| payload.get("total_token_usage"))?;
+	Some(TokenUsage {
+		input_tokens: u.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
+		cached_input_tokens: u.get("cached_input_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
+		output_tokens: u.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
+		reasoning_output_tokens: u
+			.get("reasoning_output_tokens")
+			.and_then(|v| v.as_u64())
+			.unwrap_or(0),
+		total_tokens: u.get("total_tokens").and_then(|v| v.as_u64()).unwrap_or(0),
+	})
+}
+
+/// Best-effort parse of ` usage={input:N,...}` notes we embed in codex
+/// CLI error strings so failed sessions can still be attributed.
+pub fn parse_usage_note_from_error(msg: &str) -> Option<TokenUsage> {
+	let start = msg.find("usage={")?;
+	let rest = &msg[start + "usage={".len()..];
+	let end = rest.find('}')?;
+	let body = &rest[..end];
+	let mut u = TokenUsage::default();
+	for part in body.split(',') {
+		let mut kv = part.splitn(2, ':');
+		let key = kv.next()?.trim();
+		let val: u64 = kv.next()?.trim().parse().ok()?;
+		match key {
+			"input" => u.input_tokens = val,
+			"cached_input" => u.cached_input_tokens = val,
+			"output" => u.output_tokens = val,
+			"reasoning_output" => u.reasoning_output_tokens = val,
+			"total" => u.total_tokens = val,
+			_ => {},
+		}
+	}
+	if u.is_zero() {
+		None
+	} else {
+		Some(u)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parses_token_count_and_prefers_richest_total() {
+		let stdout = r#"
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":10,"output_tokens":5,"reasoning_output_tokens":2,"total_tokens":105}}}}
+{"type":"event_msg","payload":{"type":"agent_message","message":"working...","phase":"commentary"}}
+{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":500,"cached_input_tokens":200,"output_tokens":40,"reasoning_output_tokens":10,"total_tokens":540}}}}
+{"type":"event_msg","payload":{"type":"agent_message","message":"done","phase":"final"}}
+{"type":"event_msg","payload":{"type":"task_complete","last_agent_message":"done"}}
+"#;
+		let (text, usage) = parse_codex_jsonl(stdout);
+		assert_eq!(text, "done");
+		let u = usage.expect("usage");
+		assert_eq!(u.total_tokens, 540);
+		assert_eq!(u.input_tokens, 500);
+		assert_eq!(u.cached_input_tokens, 200);
+		assert_eq!(u.output_tokens, 40);
+		assert_eq!(u.reasoning_output_tokens, 10);
+	}
+
+	#[test]
+	fn ignores_non_json_noise() {
+		let (text, usage) = parse_codex_jsonl("not json\n{\"type\":\"other\"}\n");
+		assert!(text.is_empty());
+		assert!(usage.is_none());
+	}
+
+	#[test]
+	fn parses_usage_note_from_error() {
+		let msg = "codex CLI exited with exit status: 1: blah usage={input:10,cached_input:2,output:3,reasoning_output:1,total:14}";
+		let u = parse_usage_note_from_error(msg).unwrap();
+		assert_eq!(u.total_tokens, 14);
+		assert_eq!(u.input_tokens, 10);
+	}
+
+	#[test]
+	fn recorder_persists_and_hydrates() {
+		let dir = tempfile::tempdir().unwrap();
+		let rec = UsageRecorder::open(dir.path()).unwrap();
+		rec.record(UsageEvent {
+			ts_unix_ms: 1,
+			backend: "codex-cli".into(),
+			model: "glm-5.2".into(),
+			provider: Some("zai".into()),
+			repo_id: Some(1),
+			job_id: Some(2),
+			finding_id: None,
+			file: Some("src/lib.rs".into()),
+			ok: true,
+			elapsed_ms: 10,
+			usage: TokenUsage {
+				input_tokens: 1000,
+				cached_input_tokens: 100,
+				output_tokens: 50,
+				reasoning_output_tokens: 10,
+				total_tokens: 1050,
+			},
+			estimated_usd: None,
+		});
+		assert_eq!(rec.total_tokens.load(Ordering::Relaxed), 1050);
+		assert!(rec.jsonl_path().exists());
+		// New recorder hydrates.
+		let rec2 = UsageRecorder::open(dir.path()).unwrap();
+		assert_eq!(rec2.total_tokens.load(Ordering::Relaxed), 1050);
+		assert_eq!(rec2.sessions.load(Ordering::Relaxed), 1);
+	}
+}

--- a/crates/loupe-worker/src/main.rs
+++ b/crates/loupe-worker/src/main.rs
@@ -323,13 +323,15 @@ async fn run_worker(args: RunArgs, cfg: WorkerConfig) -> Result<()> {
 		bkb_api_url: cfg.bkb.api_url.clone(),
 	};
 
+	let scan_codex = cfg.agents.scan_model.clone().unwrap_or_else(|| cfg.agents.codex.clone());
+	let scan_claude = cfg.agents.scan_model.clone().unwrap_or_else(|| cfg.agents.claude.clone());
 	if let Some(backend) = build_scan_backend(
 		Some(mcp_ctx.clone()),
 		cfg.agents.scan,
 		claude,
 		codex,
-		cfg.agents.codex.clone(),
-		cfg.agents.claude.clone(),
+		scan_codex,
+		scan_claude,
 		cfg.logging.agent_output,
 	)? {
 		scanners.push(Arc::new(
@@ -344,13 +346,16 @@ async fn run_worker(args: RunArgs, cfg: WorkerConfig) -> Result<()> {
 	// for the verify-mode tool surface (`submit_verdict` /
 	// `submit_patch` / `validate_patch`); without it, the agent has
 	// no way to commit a verdict.
+	let verify_codex = cfg.agents.verify_model.clone().unwrap_or_else(|| cfg.agents.codex.clone());
+	let verify_claude =
+		cfg.agents.verify_model.clone().unwrap_or_else(|| cfg.agents.claude.clone());
 	let backend = build_verifier_backend(
 		Some(mcp_ctx),
 		cfg.agents.verify,
 		claude,
 		codex,
-		cfg.agents.codex.clone(),
-		cfg.agents.claude.clone(),
+		verify_codex,
+		verify_claude,
 		cfg.logging.agent_output,
 	)?;
 	scanners.push(Arc::new(LlmVerifierScanner::new(backend)));

--- a/crates/loupe-worker/src/main.rs
+++ b/crates/loupe-worker/src/main.rs
@@ -19,6 +19,7 @@ use loupe_worker::config::{LoggingConfig, WorkerConfig, WorkerConfigOverrides};
 use loupe_worker::llm::{
 	bkb_mcp_available, build_scan_backend, build_verifier_backend, claude_auth_available,
 	claude_available, codex_auth_available, codex_available, JobAgent, McpContext, McpTlsSource,
+	UsageRecorder,
 };
 use loupe_worker::scanners::{LlmCodeReviewScanner, LlmVerifierScanner, RegexSecretsScanner};
 use loupe_worker::{mcp, sandbox, RepoCache, Runner, Scanner, ServerClient};
@@ -323,6 +324,18 @@ async fn run_worker(args: RunArgs, cfg: WorkerConfig) -> Result<()> {
 		bkb_api_url: cfg.bkb.api_url.clone(),
 	};
 
+	// Durable token accounting under the cache dir so funding /
+	// capacity planning can be answered from JSONL + summary without
+	// scraping provider dashboards. Optional USD estimates via
+	// LOUPE_USAGE_INPUT_USD_PER_MTOK / LOUPE_USAGE_OUTPUT_USD_PER_MTOK.
+	let usage_recorder = match UsageRecorder::open(&cache_dir) {
+		Ok(r) => Some(r),
+		Err(e) => {
+			tracing::warn!(error = %e, "usage recorder unavailable; continuing without token accounting");
+			None
+		},
+	};
+
 	let scan_codex = cfg.agents.scan_model.clone().unwrap_or_else(|| cfg.agents.codex.clone());
 	let scan_claude = cfg.agents.scan_model.clone().unwrap_or_else(|| cfg.agents.claude.clone());
 	if let Some(backend) = build_scan_backend(
@@ -333,6 +346,7 @@ async fn run_worker(args: RunArgs, cfg: WorkerConfig) -> Result<()> {
 		scan_codex,
 		scan_claude,
 		cfg.logging.agent_output,
+		usage_recorder.clone(),
 	)? {
 		scanners.push(Arc::new(
 			LlmCodeReviewScanner::new(backend)
@@ -357,6 +371,7 @@ async fn run_worker(args: RunArgs, cfg: WorkerConfig) -> Result<()> {
 		verify_codex,
 		verify_claude,
 		cfg.logging.agent_output,
+		usage_recorder,
 	)?;
 	scanners.push(Arc::new(LlmVerifierScanner::new(backend)));
 	tracing::info!("LLM verifier scanner enabled (verify:llm advertised, MCP-driven)");

--- a/crates/loupe-worker/src/runner.rs
+++ b/crates/loupe-worker/src/runner.rs
@@ -136,9 +136,9 @@ impl Runner {
 	) -> Result<(Option<String>, usize)> {
 		let key = RepoKey::new(&env.repo.host, &env.repo.owner, &env.repo.repo);
 		let clone_url = env.repo.clone_url.clone();
-		let github_pat = env.github_pat.clone();
+		let github_pat = env.clone_token.clone().or_else(|| env.github_pat.clone());
 		let mut ensured =
-			self.cache.ensure_repo(&key, &env.repo.clone_url, env.github_pat.as_deref()).await?;
+			self.cache.ensure_repo(&key, &env.repo.clone_url, github_pat.as_deref()).await?;
 		// `ensured` (and its pin) lives until the end of this fn; the
 		// repo cache won't evict the bare clone while the worktree
 		// alternate is still in use.

--- a/crates/loupe-worker/src/scanners/llm_code_review.rs
+++ b/crates/loupe-worker/src/scanners/llm_code_review.rs
@@ -22,10 +22,10 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_trait::async_trait;
 use loupe_core::Finding;
-use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use crate::llm::prompts::{self, DISCOVERY};
+use crate::llm::rate_limit::{is_rate_limit_error, AdaptiveConcurrency};
 use crate::llm::{LlmBackend, LlmRequest};
 use crate::scanner::{ScanContext, Scanner};
 use crate::source_discovery::{walk_source_files, ScannerConfig, ScannerConfigPatch};
@@ -141,7 +141,14 @@ impl Scanner for LlmCodeReviewScanner {
 }
 
 impl LlmCodeReviewScanner {
-	/// Fan out one agent session per file with bounded concurrency.
+	/// Fan out one agent session per file with adaptive concurrency.
+	///
+	/// Starts at `cfg.max_concurrent_files`. When an agent session hits
+	/// a provider rate limit (429 / exceeded retry limit / etc.), the
+	/// shared limiter halves concurrency and sleeps with exponential
+	/// backoff so the remaining files don't thrash the same quota.
+	/// Successful sessions slowly restore the ceiling.
+	///
 	/// Returns the count of session-level errors; per-session "no
 	/// finding" is a success (not an error).
 	#[allow(clippy::too_many_arguments)]
@@ -149,22 +156,38 @@ impl LlmCodeReviewScanner {
 		&self, cfg: &ScannerConfig, workdir: &Path, files: &[PathBuf], repo_id: i64, job_id: i64,
 		bkb_hint: &'static str, cancel: &CancellationToken,
 	) -> usize {
-		let sem = Arc::new(Semaphore::new(cfg.max_concurrent_files));
+		let limiter = AdaptiveConcurrency::new(cfg.max_concurrent_files);
+		tracing::info!(
+			max_concurrent_files = limiter.max(),
+			"llm-code-review: adaptive concurrency armed"
+		);
 		let mut handles = Vec::with_capacity(files.len());
 		for path in files {
 			if cancel.is_cancelled() {
 				break;
 			}
-			let permit = sem.clone().acquire_owned().await.expect("semaphore not closed");
+			// Acquire before spawn so the launcher itself backs off when
+			// the provider is hot — otherwise we'd queue every file as a
+			// task that immediately stampedes the API the moment cooldown
+			// ends.
+			let ticket = limiter.acquire().await;
+			if cancel.is_cancelled() {
+				drop(ticket);
+				break;
+			}
 			let backend = self.backend.clone();
 			let cfg_owned = cfg.clone();
 			let workdir = workdir.to_path_buf();
 			let path = path.clone();
 			let cancel = cancel.clone();
+			let limiter = Arc::clone(&limiter);
 			handles.push(tokio::spawn(async move {
-				let _permit = permit;
-				run_one(backend, &workdir, &path, &cfg_owned, repo_id, job_id, bkb_hint, cancel)
-					.await
+				let _ticket = ticket;
+				run_one(
+					backend, &workdir, &path, &cfg_owned, repo_id, job_id, bkb_hint, cancel,
+					&limiter,
+				)
+				.await
 			}));
 		}
 
@@ -179,6 +202,11 @@ impl LlmCodeReviewScanner {
 				},
 			}
 		}
+		tracing::info!(
+			final_limit = limiter.current_limit(),
+			max = limiter.max(),
+			"llm-code-review: fan-out complete"
+		);
 		errors
 	}
 }
@@ -188,14 +216,21 @@ impl LlmCodeReviewScanner {
 /// counts these and fails the scan when every attempt errors. A
 /// healthy session that produced no submission still returns `Ok(())`
 /// — the agent decided there was nothing to report.
+///
+/// Rate-limit failures are reported to `limiter` so the rest of the
+/// fan-out slows down; other errors leave concurrency unchanged.
 #[allow(clippy::too_many_arguments)]
 async fn run_one(
 	backend: Arc<dyn LlmBackend>, workdir: &Path, file: &Path, cfg: &ScannerConfig, repo_id: i64,
-	job_id: i64, bkb_hint: &'static str, cancel: CancellationToken,
+	job_id: i64, bkb_hint: &'static str, cancel: CancellationToken, limiter: &AdaptiveConcurrency,
 ) -> Result<(), ()> {
 	let rel = file.strip_prefix(workdir).unwrap_or(file).to_string_lossy().into_owned();
 	let prompt = prompts::render(DISCOVERY, &[("file", &rel), ("bkb_hint", bkb_hint)]);
-	tracing::info!(file = %rel, "llm-code-review: launching agent session");
+	tracing::info!(
+		file = %rel,
+		concurrency_limit = limiter.current_limit(),
+		"llm-code-review: launching agent session"
+	);
 	let started = std::time::Instant::now();
 	let req = LlmRequest {
 		prompt,
@@ -208,6 +243,7 @@ async fn run_one(
 	};
 	match backend.run(req).await {
 		Ok(r) => {
+			limiter.record_success();
 			tracing::debug!(
 				file = %rel,
 				elapsed_ms = started.elapsed().as_millis() as u64,
@@ -217,7 +253,18 @@ async fn run_one(
 			Ok(())
 		},
 		Err(e) => {
-			tracing::warn!(file = %rel, error = %e, "agent session failed");
+			if is_rate_limit_error(&e) {
+				limiter.record_rate_limit(&format!("{e:#}"));
+				tracing::warn!(
+					file = %rel,
+					error = %e,
+					concurrency_limit = limiter.current_limit(),
+					"agent session failed (rate limit) — fan-out will slow down"
+				);
+			} else {
+				limiter.record_other_error();
+				tracing::warn!(file = %rel, error = %e, "agent session failed");
+			}
 			Err(())
 		},
 	}

--- a/crates/loupe-worker/src/scanners/llm_code_review.rs
+++ b/crates/loupe-worker/src/scanners/llm_code_review.rs
@@ -240,6 +240,7 @@ async fn run_one(
 		repo_id: Some(repo_id),
 		job_id: Some(job_id),
 		finding_id: None,
+		usage_label: Some(rel.clone()),
 	};
 	match backend.run(req).await {
 		Ok(r) => {

--- a/crates/loupe-worker/src/scanners/llm_verifier.rs
+++ b/crates/loupe-worker/src/scanners/llm_verifier.rs
@@ -89,6 +89,7 @@ impl Scanner for LlmVerifierScanner {
 			repo_id: Some(ctx.repo_id),
 			job_id: Some(ctx.job_id),
 			finding_id: Some(ctx.finding_id),
+			usage_label: Some(format!("finding:{}", ctx.finding_id)),
 		};
 		let _resp = self.backend.run(req).await?;
 

--- a/crates/loupe-worker/tests/end_to_end.rs
+++ b/crates/loupe-worker/tests/end_to_end.rs
@@ -100,6 +100,7 @@ async fn worker_runs_a_scan_and_emits_a_finding() {
 		.json(&RegisterRepoRequest {
 			protocol_version: PROTOCOL_VERSION,
 			clone_url: "https://github.com/loupe/test-target.git".into(),
+			clone_token: None,
 			branch: None,
 			scan_interval_seconds: None,
 			reporting: ReportingSetup::GithubIssue {


### PR DESCRIPTION
## Summary

Four operator-facing features from self-hosting Loupe against paid LLM providers, one commit each:

- **Private-repo clone tokens** (`6f0563c`): scanning a private repo today means embedding credentials in `clone_url` (leaked by `repo list`) — the reporting PAT is deliberately never shipped to workers. `RegisterRepoRequest.clone_token` is stored as a new `SecretKind::CloneToken` in the SQLCipher-sealed secrets table (migration v2 adds `registered_repos.clone_token_secret_id`), decrypted into the lease envelope, and the worker prefers it over `github_pat` for clone/fetch. The CLI reads `LOUPE_CLONE_TOKEN` so the token never touches shell history either.
- **Per-role model/provider overrides** (`1d4ae3b`): scan and verify previously shared one backend config, forcing a single model + API key for both. New optional `[agents.scan_model]` / `[agents.verify_model]` sections override model/effort per role; `provider` emits `-c model_provider=...` and `api_key_env` injects a per-invocation key, so two roles sharing the codex backend can target distinct OpenAI-compatible providers (e.g. cheap GLM for discovery, a stronger model for verify).
- **Adaptive rate-limit backoff** (`dbf46de`): the discovery fan-out launches one agent session per file; when a provider starts returning 429s, N sessions thrash the same quota until every file fails. A shared `AdaptiveConcurrency` pool now halves concurrency (floor 1) and arms exponential cooldown (20s base, 5min cap) on classified rate-limit errors, and slowly restores the ceiling on success. Other errors don't change concurrency.
- **LLM token-usage accounting** (`0c5bfe8`): no way to answer "how many tokens did we burn this week?" without scraping provider dashboards. Codex now runs with `--json`; per-session `UsageEvent` rows (backend/model/provider/repo/job/file + counters, optional USD estimate via `LOUPE_USAGE_*_USD_PER_MTOK`) append to `usage/llm-usage.jsonl` under the worker cache, with a summary snapshot and hydration across restarts. Failed/rate-limited sessions still record partial usage.

## Review Notes

- Production-safety review passed (2 rounds). Fixed before shipping: clone token computed but never passed to `ensure_repo` (private repos would never have cloned), a duplicated secrets getter, silently-swallowed secret decryption errors in lease building, and a lost-wakeup race in the limiter (`notify_waiters` doesn't store permits — used the `Notified::enable()` idiom).
- Each commit compiles and passes `cargo test` on its own; workspace `fmt --check` / `clippy -D warnings` / `test` green at the tip.
- Deliberately excluded as deployment-specific: a Dockerfile codex version pin and a docker-entrypoint allowlist entry for an extra provider API-key env var. The `api_key_env` feature may want the entrypoint to accept additional `*_API_KEY` secrets — happy to send that as a follow-up if you want it.
- `LeaseEnvelope` / `RegisterRepoRequest` changes are additive optional fields (no `deny_unknown_fields`), so no protocol version bump; old workers ignore `clone_token`.

## Decision Log

**Hardest decision:** switching codex to always run with `--json` (`codex_cli.rs`). It changes stdout from plain text to a JSONL event stream, so response text is now extracted by parsing (final `agent_message`, falling back to `task_complete.last_agent_message`). Chosen because `token_count` events are the only durable usage signal codex exposes; the fallback chain keeps text extraction working for sessions that end via MCP tool calls without a final message. The claude backend stays text-mode and records zero-usage session events.

**Alternatives rejected:**
- Embedding clone credentials in `clone_url` (the status quo): leaks via `repo list` and any log line that prints the URL.
- Passing a per-provider config file path instead of `provider`/`api_key_env` scalars: pushes file management into the sandbox; scalar `-c` overrides ride the existing invocation-args path.
- A semaphore with dynamic permits for the limiter: `tokio::sync::Semaphore` can't shrink below issued permits cleanly; the permit-pool with `Notify` is ~100 lines and testable.

**Least confident about:** `UsageRecorder::record` does synchronous file I/O (append + summary rewrite) under a mutex on the async path — bounded and once per session, but under heavy fan-out it's on the hot path; `spawn_blocking` would be the follow-up if profiling shows it. Also `is_rate_limit_message` is substring matching ("429", "retry limit", ...) across codex/claude/proxy phrasings — loose by design, could false-positive on an unrelated error containing those strings.

## Test plan

- [ ] CI passes
- [ ] `loupe-cli repo add` a private repo with `LOUPE_CLONE_TOKEN` set; worker clones it; `repo list` shows no credential
- [ ] `[agents.verify_model]` with a distinct `provider` + `api_key_env` routes verify jobs to the second provider while scan stays on the default
- [ ] A provider returning 429s reduces fan-out concurrency (log: "slowing fan-out") and recovers after successes
- [ ] `usage/llm-usage.jsonl` gains a row per session; `llm-usage-summary.json` totals survive worker restart
