### PR TITLE
worker: forward ANTHROPIC_BASE_URL into the claude sandbox

### DIFF
--- a/crates/loupe-worker/src/llm/claude_cli.rs
+++ b/crates/loupe-worker/src/llm/claude_cli.rs
@@ -38,6 +38,23 @@ pub const DEFAULT_CLAUDE_MODEL: &str = "claude-opus-4-7";
 pub const DEFAULT_CLAUDE_EFFORT: &str = "max";
 const MAX_CLI_DIAGNOSTIC_CHARS: usize = 2_000;
 
+/// Environment the claude CLI needs to see *inside* the sandbox.
+///
+/// The sandbox runs with `--clearenv`, so anything absent from this
+/// list is invisible to the CLI. `ANTHROPIC_API_KEY` covers env-based
+/// auth against Anthropic itself. The other two matter for
+/// Anthropic-compatible third-party endpoints (Kimi, gateways,
+/// self-hosted proxies): `ANTHROPIC_BASE_URL` selects the endpoint and
+/// `ANTHROPIC_AUTH_TOKEN` is the bearer token those endpoints
+/// typically expect.
+///
+/// Leaving the base URL out doesn't fail loudly — the CLI just falls
+/// back to api.anthropic.com. The operator's scan appears to work
+/// while every request goes to the wrong provider, on the wrong
+/// account, with the wrong model.
+const FORWARDED_CLAUDE_ENV: &[&str] =
+	&["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_AUTH_TOKEN"];
+
 /// Fixed sandbox path for the per-call MCP config file claude reads.
 /// The host-side scratch dir (a `tempfile::TempDir`) bind-mounts
 /// onto this path; dropping the scratch dir unlinks the source
@@ -206,10 +223,10 @@ impl LlmBackend for ClaudeCliBackend {
 			// without this.
 			.allow_binary(&self.bin)
 			.with_context(|| format!("preparing sandbox for `{}`", self.bin))?
-			// Forward auth: ANTHROPIC_API_KEY for env-based auth, plus
-			// any user-managed login state under ~/.claude/* which
-			// `claude /login` writes to.
-			.forward_env("ANTHROPIC_API_KEY");
+			// Forward auth and endpoint selection, plus any user-managed
+			// login state under ~/.claude/* which `claude /login` writes
+			// to. See FORWARDED_CLAUDE_ENV.
+			.forward_env_all(FORWARDED_CLAUDE_ENV);
 		if let Some(home) = std::env::var_os("HOME") {
 			let host_home = std::path::PathBuf::from(home);
 			let claude_dir = host_home.join(".claude");
@@ -567,5 +584,23 @@ mod tests {
 		assert!(args.windows(2).any(|w| w == ["--model", "claude-test"]));
 		assert!(args.windows(2).any(|w| w == ["--effort", "xhigh"]));
 		assert!(args.windows(2).any(|w| w == ["-p", "hello"]));
+	}
+
+	/// The sandbox is `--clearenv`, so an endpoint override the
+	/// operator sets on the worker only reaches the CLI if it is on the
+	/// forward list. Dropping `ANTHROPIC_BASE_URL` sends every request
+	/// to api.anthropic.com instead of the configured endpoint, and
+	/// nothing about the run looks wrong.
+	#[test]
+	fn forwarded_env_carries_endpoint_selection_not_just_the_api_key() {
+		assert!(
+			FORWARDED_CLAUDE_ENV.contains(&"ANTHROPIC_BASE_URL"),
+			"base URL must survive --clearenv or third-party endpoints silently fall back",
+		);
+		assert!(
+			FORWARDED_CLAUDE_ENV.contains(&"ANTHROPIC_AUTH_TOKEN"),
+			"Anthropic-compatible endpoints authenticate with ANTHROPIC_AUTH_TOKEN",
+		);
+		assert!(FORWARDED_CLAUDE_ENV.contains(&"ANTHROPIC_API_KEY"));
 	}
 }

--- a/crates/loupe-worker/src/sandbox.rs
+++ b/crates/loupe-worker/src/sandbox.rs
@@ -117,6 +117,14 @@ impl SandboxBuilder {
 		self
 	}
 
+	/// Forward a whole set of env vars. Same semantics as
+	/// [`Self::forward_env`]; convenient when a backend keeps its
+	/// forwarded environment in one named list.
+	pub fn forward_env_all(mut self, names: &[&'static str]) -> Self {
+		self.forward_env.extend_from_slice(names);
+		self
+	}
+
 	/// Set an env var to a caller-provided value inside the sandbox.
 	/// This is useful when a backend accepts one env name but Loupe
 	/// supports a compatibility alias at the worker boundary.
@@ -710,6 +718,30 @@ mod tests {
 		);
 
 		std::env::remove_var("LOUPE_SANDBOX_TEST_SECRET");
+	}
+
+	#[test]
+	fn forward_env_all_passes_every_name_in_the_list() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		std::env::set_var("LOUPE_SANDBOX_TEST_ONE", "one");
+		std::env::set_var("LOUPE_SANDBOX_TEST_TWO", "two");
+
+		let cmd = SandboxBuilder::new("/tmp")
+			.forward_env_all(&["LOUPE_SANDBOX_TEST_ONE", "LOUPE_SANDBOX_TEST_TWO"])
+			.build("/bin/true");
+		let args: Vec<String> =
+			cmd.as_std().get_args().map(|s| s.to_string_lossy().into_owned()).collect();
+
+		for (name, value) in [("LOUPE_SANDBOX_TEST_ONE", "one"), ("LOUPE_SANDBOX_TEST_TWO", "two")]
+		{
+			assert!(
+				args.windows(3).any(|w| w[0] == "--setenv" && w[1] == name && w[2] == value),
+				"{name} not forwarded; args: {args:?}"
+			);
+		}
+
+		std::env::remove_var("LOUPE_SANDBOX_TEST_ONE");
+		std::env::remove_var("LOUPE_SANDBOX_TEST_TWO");
 	}
 
 	#[test]


### PR DESCRIPTION
The bubblewrap sandbox runs with --clearenv and forwarded only ANTHROPIC_API_KEY. An operator pointing the worker at an Anthropic-compatible third-party endpoint (Kimi, a gateway, a self-hosted proxy) sets ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN on the worker, and neither survived into the CLI's environment.

The failure is silent rather than loud: without a base URL the claude CLI falls back to api.anthropic.com. The scan runs, files are reviewed, findings come back — against the wrong provider, billed to whatever Anthropic credentials happen to be reachable, using a model the operator did not choose. Nothing in the logs says so.

Move the forwarded set into a named FORWARDED_CLAUDE_ENV list so the sandbox's environment contract is stated in one place, and add SandboxBuilder::forward_env_all to pass it in one call.

Found while running a worker against Kimi K3 through the Anthropic-compatible endpoint at api.moonshot.ai.