### PR TITLE
worker: resolve MCP paths to host locations when the sandbox is off

### DIFF
--- a/crates/loupe-worker/src/llm/claude_cli.rs
+++ b/crates/loupe-worker/src/llm/claude_cli.rs
@@ -26,9 +26,7 @@ use async_trait::async_trait;
 use tokio::io::AsyncReadExt;
 use tokio::time::timeout;
 
-use super::mcp::{
-	bind_mcp_into_sandbox, mcp_serve_args, McpContext, SANDBOX_BKB_MCP_BIN, SANDBOX_LOUPE_BIN,
-};
+use super::mcp::{bind_mcp_into_sandbox, mcp_serve_args, McpContext, McpPaths};
 use super::{summarize_cli_stream_for_error, CliModelConfig, LlmBackend, LlmRequest, LlmResponse};
 use crate::sandbox::SandboxBuilder;
 
@@ -64,6 +62,7 @@ fn prepare_mcp_scratch(
 		.context("creating MCP scratch tempdir")?;
 	let config_path = dir.path().join("mcp-config.json");
 	let args = mcp_serve_args(ctx, repo_id, job_id, finding_id, sandbox_workdir);
+	let paths = McpPaths::resolve(ctx);
 	let mut servers = serde_json::Map::new();
 	servers.insert(
 		"loupe".to_string(),
@@ -71,8 +70,9 @@ fn prepare_mcp_scratch(
 			"type": "stdio",
 			// Inside the sandbox the worker binary is mounted at
 			// SANDBOX_LOUPE_BIN, the cert files under /loupe/...
-			// — see the bind_ro calls above.
-			"command": SANDBOX_LOUPE_BIN,
+			// — see the bind_ro calls above. With the sandbox
+			// disabled these resolve to their host locations.
+			"command": paths.loupe_bin,
 			"args": args,
 			// The MCP child inherits the bwrap'd env, which has
 			// HOME=/home/scanner + the forwarded ANTHROPIC_API_KEY
@@ -93,7 +93,7 @@ fn prepare_mcp_scratch(
 			"bkb".to_string(),
 			serde_json::json!({
 				"type": "stdio",
-				"command": SANDBOX_BKB_MCP_BIN,
+				"command": paths.bkb_bin,
 				"args": [],
 				"env": { "BKB_API_URL": ctx.bkb_api_url.as_str() }
 			}),
@@ -260,8 +260,14 @@ impl LlmBackend for ClaudeCliBackend {
 		for arg in claude_invocation_args(&self.agent, &req.prompt) {
 			cmd.arg(arg);
 		}
-		if _mcp_scratch.is_some() {
-			cmd.arg("--mcp-config").arg(SANDBOX_MCP_CONFIG);
+		if let Some(scratch) = &_mcp_scratch {
+			// The bind_ro onto SANDBOX_MCP_CONFIG is a no-op when the
+			// sandbox is off, so point claude at the host scratch file.
+			if crate::sandbox::sandbox_disabled() {
+				cmd.arg("--mcp-config").arg(&scratch.config_path);
+			} else {
+				cmd.arg("--mcp-config").arg(SANDBOX_MCP_CONFIG);
+			}
 		}
 		cmd.stdin(Stdio::null()).stdout(Stdio::piped()).stderr(Stdio::piped());
 		cmd.kill_on_drop(true);

--- a/crates/loupe-worker/src/llm/codex_cli.rs
+++ b/crates/loupe-worker/src/llm/codex_cli.rs
@@ -28,9 +28,7 @@ use async_trait::async_trait;
 use tokio::io::AsyncReadExt;
 use tokio::time::timeout;
 
-use super::mcp::{
-	bind_mcp_into_sandbox, mcp_serve_args, McpContext, SANDBOX_BKB_MCP_BIN, SANDBOX_LOUPE_BIN,
-};
+use super::mcp::{bind_mcp_into_sandbox, mcp_serve_args, McpContext, McpPaths};
 use super::{
 	codex_api_key_env, codex_home_dir, summarize_cli_stream_for_error, CliModelConfig, LlmBackend,
 	LlmRequest, LlmResponse,
@@ -213,17 +211,18 @@ impl LlmBackend for CodexCliBackend {
 				sandbox = bind_mcp_into_sandbox(sandbox, ctx);
 				let args =
 					mcp_serve_args(ctx, repo_id, req.job_id, req.finding_id, &sandbox_workdir);
+				let paths = McpPaths::resolve(ctx);
 				let mut overrides = Vec::new();
 				overrides.push(format!(
 					"mcp_servers.loupe.command={}",
-					toml_string_literal(SANDBOX_LOUPE_BIN)
+					toml_string_literal(&paths.loupe_bin)
 				));
 				overrides.push(format!("mcp_servers.loupe.args={}", toml_string_array(&args)));
 				overrides.push("mcp_servers.loupe.env={}".to_owned());
 				if ctx.bkb_mcp_path.is_some() {
 					overrides.push(format!(
 						"mcp_servers.bkb.command={}",
-						toml_string_literal(SANDBOX_BKB_MCP_BIN)
+						toml_string_literal(&paths.bkb_bin)
 					));
 					overrides.push("mcp_servers.bkb.args=[]".to_owned());
 					overrides.push(format!(

--- a/crates/loupe-worker/src/llm/mcp.rs
+++ b/crates/loupe-worker/src/llm/mcp.rs
@@ -71,9 +71,60 @@ pub enum McpTlsSource {
 	Env,
 }
 
+/// Where the agent's MCP child looks for the worker binary, the mTLS
+/// material, and bkb-mcp.
+///
+/// Under bubblewrap these are the fixed `/loupe/...` mount points that
+/// [`bind_mcp_into_sandbox`] creates. With `LOUPE_DISABLE_SANDBOX` set
+/// there are no mounts at all — the child sees the host filesystem —
+/// so those same paths resolve to nothing and every agent session dies
+/// before it starts. Resolve to the real host paths in that case.
+pub struct McpPaths {
+	pub loupe_bin: String,
+	pub bkb_bin: String,
+	pub ca_cert: String,
+	pub client_cert: String,
+	pub client_key: String,
+}
+
+impl McpPaths {
+	pub fn resolve(ctx: &McpContext) -> Self {
+		if !crate::sandbox::sandbox_disabled() {
+			return Self {
+				loupe_bin: SANDBOX_LOUPE_BIN.to_owned(),
+				bkb_bin: SANDBOX_BKB_MCP_BIN.to_owned(),
+				ca_cert: SANDBOX_CA_CERT.to_owned(),
+				client_cert: SANDBOX_CLIENT_CERT.to_owned(),
+				client_key: SANDBOX_CLIENT_KEY.to_owned(),
+			};
+		}
+		let (ca_cert, client_cert, client_key) = match &ctx.tls {
+			McpTlsSource::Paths { ca_cert_path, client_cert_path, client_key_path } => (
+				ca_cert_path.to_string_lossy().into_owned(),
+				client_cert_path.to_string_lossy().into_owned(),
+				client_key_path.to_string_lossy().into_owned(),
+			),
+			// Env-sourced TLS: the child reads PEMs from the inherited
+			// environment, so no paths are passed as args.
+			McpTlsSource::Env => (String::new(), String::new(), String::new()),
+		};
+		Self {
+			loupe_bin: ctx.worker_binary.to_string_lossy().into_owned(),
+			bkb_bin: ctx
+				.bkb_mcp_path
+				.as_ref()
+				.map(|p| p.to_string_lossy().into_owned())
+				.unwrap_or_else(|| SANDBOX_BKB_MCP_BIN.to_owned()),
+			ca_cert,
+			client_cert,
+			client_key,
+		}
+	}
+}
+
 /// Build the args list that gets appended to `loupe-worker
 /// mcp-serve` for one MCP-attached agent invocation. Cert + binary
-/// paths come from the sandbox fixed paths above; per-call data
+/// paths come from [`McpPaths`]; per-call data
 /// (`repo_id`, `job_id`, `finding_id`, `sandbox_workdir`) is wired
 /// by the caller.
 ///
@@ -88,6 +139,7 @@ pub fn mcp_serve_args(
 	ctx: &McpContext, repo_id: i64, job_id: Option<i64>, finding_id: Option<i64>,
 	sandbox_workdir: &str,
 ) -> Vec<String> {
+	let paths = McpPaths::resolve(ctx);
 	let mut args: Vec<String> = vec![
 		"mcp-serve".into(),
 		"--server-url".into(),
@@ -102,11 +154,11 @@ pub fn mcp_serve_args(
 			3..3,
 			[
 				"--ca-cert".into(),
-				SANDBOX_CA_CERT.into(),
+				paths.ca_cert.clone(),
 				"--cert".into(),
-				SANDBOX_CLIENT_CERT.into(),
+				paths.client_cert.clone(),
 				"--key".into(),
-				SANDBOX_CLIENT_KEY.into(),
+				paths.client_key.clone(),
 			],
 		);
 	}
@@ -147,4 +199,83 @@ pub fn bind_mcp_into_sandbox(sandbox: SandboxBuilder, ctx: &McpContext) -> Sandb
 		sb = sb.bind_ro(bkb_path.clone(), SANDBOX_BKB_MCP_BIN);
 	}
 	sb
+}
+
+#[cfg(test)]
+mod tests {
+	use std::path::PathBuf;
+	use std::sync::Mutex;
+
+	use super::*;
+	use crate::sandbox::DISABLE_SANDBOX_ENV;
+
+	static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	fn ctx() -> McpContext {
+		McpContext {
+			worker_binary: PathBuf::from("/opt/loupe/bin/loupe-worker"),
+			server_url: "https://loupe.example:8443".to_owned(),
+			tls: McpTlsSource::Paths {
+				ca_cert_path: PathBuf::from("/etc/loupe/ca.pem"),
+				client_cert_path: PathBuf::from("/etc/loupe/worker.pem"),
+				client_key_path: PathBuf::from("/etc/loupe/worker.key"),
+			},
+			bkb_mcp_path: Some(PathBuf::from("/home/op/.cargo/bin/bkb-mcp")),
+			bkb_api_url: DEFAULT_BKB_API_URL.to_owned(),
+		}
+	}
+
+	#[test]
+	fn sandboxed_runs_use_the_fixed_mount_points() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		std::env::remove_var(DISABLE_SANDBOX_ENV);
+
+		let paths = McpPaths::resolve(&ctx());
+
+		assert_eq!(paths.loupe_bin, SANDBOX_LOUPE_BIN);
+		assert_eq!(paths.ca_cert, SANDBOX_CA_CERT);
+		assert_eq!(paths.client_cert, SANDBOX_CLIENT_CERT);
+		assert_eq!(paths.client_key, SANDBOX_CLIENT_KEY);
+		assert_eq!(paths.bkb_bin, SANDBOX_BKB_MCP_BIN);
+	}
+
+	/// With the sandbox disabled there are no bind mounts, so the fixed
+	/// `/loupe/...` paths point at nothing. Handing them to the agent
+	/// makes every session die instantly with "MCP config file not
+	/// found", which the scanner reports as a per-file session error —
+	/// the job still completes and the repo looks clean.
+	#[test]
+	fn sandbox_disabled_runs_resolve_to_host_paths() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		std::env::set_var(DISABLE_SANDBOX_ENV, "1");
+
+		let paths = McpPaths::resolve(&ctx());
+
+		assert_eq!(paths.loupe_bin, "/opt/loupe/bin/loupe-worker");
+		assert_eq!(paths.ca_cert, "/etc/loupe/ca.pem");
+		assert_eq!(paths.client_cert, "/etc/loupe/worker.pem");
+		assert_eq!(paths.client_key, "/etc/loupe/worker.key");
+		assert_eq!(paths.bkb_bin, "/home/op/.cargo/bin/bkb-mcp");
+		assert!(
+			!paths.loupe_bin.starts_with("/loupe/"),
+			"a /loupe/ path outside the sandbox is a mount point that does not exist",
+		);
+
+		std::env::remove_var(DISABLE_SANDBOX_ENV);
+	}
+
+	#[test]
+	fn env_sourced_tls_passes_no_cert_paths() {
+		let _guard = ENV_LOCK.lock().unwrap();
+		std::env::set_var(DISABLE_SANDBOX_ENV, "1");
+
+		let mut c = ctx();
+		c.tls = McpTlsSource::Env;
+		let args = mcp_serve_args(&c, 7, Some(9), None, "/tmp/work");
+
+		assert!(!args.iter().any(|a| a == "--ca-cert"), "args: {args:?}");
+		assert!(args.windows(2).any(|w| w == ["--repo-id", "7"]), "args: {args:?}");
+
+		std::env::remove_var(DISABLE_SANDBOX_ENV);
+	}
 }

--- a/crates/loupe-worker/src/sandbox.rs
+++ b/crates/loupe-worker/src/sandbox.rs
@@ -268,7 +268,11 @@ impl SandboxBuilder {
 	}
 }
 
-fn sandbox_disabled() -> bool {
+/// Whether the sandbox is switched off for this process. Backends need
+/// this because a disabled sandbox has no bind mounts: any path that
+/// only exists as a mount point inside `bwrap` has to be resolved to
+/// its real host location instead.
+pub fn sandbox_disabled() -> bool {
 	std::env::var_os(DISABLE_SANDBOX_ENV).is_some_and(|v| {
 		let value = v.to_string_lossy();
 		if value.is_empty() {


### PR DESCRIPTION
`LOUPE_DISABLE_SANDBOX=1` is documented as the escape hatch for hosts without bubblewrap. With it set, the LLM code-review scanner cannot run at all: every agent session exits immediately with

    Error: Invalid MCP configuration: MCP config file not found:
    /loupe/mcp-config.json

`/loupe/...` are bwrap mount points. With the sandbox disabled there are no mounts, so the MCP config, the worker binary the MCP child execs, the mTLS cert/key/CA it authenticates with, and bkb-mcp are all handed to the agent as paths that do not exist. Only the worktree path was special-cased for this mode.

macOS has no bubblewrap port, so this is every macOS worker: the scanner has never worked there. It fails quietly. Each session is counted as a per-file error, and the scan only hard-fails when *every* file errors — so a repo where some files scanned before the config went missing reports success with partial findings, and one where the whole run failed reports "0 findings" that reads as a clean repo.

Add McpPaths::resolve(), which returns the fixed mount points under bwrap and the real host paths otherwise, and route both backends through it. Make sandbox_disabled() pub so backends can ask.

Observed on macOS running a scan of a 46-file repo: 70/70 sessions errored, job state "succeeded", findings 0.