### PR TITLE
worker: abort the scan when the server reclaims the lease

### DIFF
--- a/crates/loupe-storage/src/jobs.rs
+++ b/crates/loupe-storage/src/jobs.rs
@@ -12,7 +12,16 @@ use rusqlite::{params, Connection, OptionalExtension};
 
 /// Lease lifetime in seconds. Worker must heartbeat or complete before
 /// `lease_expires_at` or the reaper will reclaim the job.
-pub const DEFAULT_LEASE_SECONDS: i64 = 600;
+///
+/// Sized for whole-repo LLM scans, which run for hours. The failure a
+/// short TTL protects against — a dead worker sitting on a job — is
+/// already caught by the 60s heartbeat, which detects a crashed worker
+/// within a minute regardless of this value. What a short TTL adds is
+/// a race the heartbeat cannot win: any pause longer than the TTL (a
+/// laptop suspending, a stalled host, a long VM freeze) lets the
+/// reaper take a live job away, and on resume the reaper's 15s tick
+/// fires before the worker's next 60s heartbeat.
+pub const DEFAULT_LEASE_SECONDS: i64 = 7200;
 
 /// Cap on retry attempts. After this many leases-then-failures, the job
 /// is moved to `failed` rather than back to `queued`.

--- a/crates/loupe-worker/src/client.rs
+++ b/crates/loupe-worker/src/client.rs
@@ -10,6 +10,20 @@ use loupe_proto::{
 };
 use reqwest::Url;
 
+/// The server no longer considers this worker the holder of the job's
+/// lease — the reaper reclaimed it after the lease TTL elapsed.
+///
+/// Typed because the correct response is different from every other
+/// heartbeat error. A network blip is worth retrying; this is not.
+/// Once the lease is gone, the findings the scan submits and the
+/// completion call it ends with are all rejected, so continuing to
+/// scan produces nothing but load and, with an LLM scanner, spend.
+#[derive(Debug, thiserror::Error)]
+#[error("lease for job {job_id} is no longer held by this worker")]
+pub struct LeaseLost {
+	pub job_id: i64,
+}
+
 pub struct ServerClient {
 	http: reqwest::Client,
 	base: Url,
@@ -62,6 +76,9 @@ impl ServerClient {
 			.send()
 			.await
 			.context("heartbeat request")?;
+		if resp.status() == reqwest::StatusCode::FORBIDDEN {
+			return Err(anyhow::Error::new(LeaseLost { job_id }));
+		}
 		let resp = ensure_ok(resp).await?;
 		resp.json().await.context("decoding heartbeat")
 	}
@@ -207,6 +224,22 @@ mod tests {
 			msg.contains(body),
 			"error should include response body so worker logs show the failure reason: {msg}",
 		);
+	}
+
+	/// A reclaimed lease must be distinguishable from a transient
+	/// heartbeat failure. The runner keys its abort decision on the
+	/// type: everything else is retryable, this is not.
+	#[tokio::test]
+	async fn heartbeat_403_is_a_typed_lease_loss() {
+		let base = serve_once("HTTP/1.1 403 Forbidden", "lease not held by this worker").await;
+		let client = ServerClient::from_parts(reqwest::Client::new(), base);
+
+		let err = client.heartbeat(4242).await.expect_err("403 must be an error");
+
+		let lost = err
+			.downcast_ref::<LeaseLost>()
+			.expect("403 on heartbeat must surface as LeaseLost, not an opaque anyhow");
+		assert_eq!(lost.job_id, 4242);
 	}
 
 	async fn serve_once(status_line: &str, body: &str) -> Url {

--- a/crates/loupe-worker/src/runner.rs
+++ b/crates/loupe-worker/src/runner.rs
@@ -362,6 +362,20 @@ impl Runner {
 					_ = cancel.cancelled() => return,
 					_ = tokio::time::sleep(HEARTBEAT_INTERVAL) => {
 						if let Err(e) = client.heartbeat(job_id).await {
+							if e.downcast_ref::<crate::client::LeaseLost>().is_some() {
+								// Terminal: the job belongs to someone
+								// else now. Cancelling the scan token
+								// tears down the in-flight sessions
+								// rather than letting them run to
+								// completion only to be rejected.
+								tracing::error!(
+									job_id,
+									"lease reclaimed by server; aborting scan — work from here on \
+									 would be rejected",
+								);
+								cancel.cancel();
+								return;
+							}
 							tracing::warn!(job_id, error = %e, "heartbeat failed");
 						}
 					},


### PR DESCRIPTION
A worker that loses its lease keeps scanning. The heartbeat logs `heartbeat failed ... 403 Forbidden: lease not held by this worker` once a minute and the loop carries on, but every finding the scan submits from that point is rejected and so is the completion call. The job sits in `queued` while the worker burns through the rest of the repo producing nothing.

With an LLM scanner that is real money. Observed here: the lease was reclaimed 2h45m into a 3h scan of a 46-file repo, and the worker logged 19 consecutive 403s while continuing to run agent sessions whose output the server had already stopped accepting.

Two changes:

1. Type the 403. `LeaseLost` is distinguishable from a transient heartbeat failure, and the runner cancels the scan token on it, which tears down in-flight sessions instead of letting them finish into a closed door. Other heartbeat errors stay retryable.

2. Size DEFAULT_LEASE_SECONDS for the jobs that actually exist. 600s against a multi-hour scan means the lease depends on ~180 consecutive heartbeats landing. The thing a short TTL guards against — a dead worker holding a job — is already caught by the 60s heartbeat, which notices a crash within a minute whatever the TTL is. What the short TTL adds is a race the heartbeat cannot win: pause the host for longer than the TTL and, on resume, the reaper's 15s tick fires before the worker's 60s heartbeat. A laptop suspending is enough. 7200s removes the race without weakening crash detection.